### PR TITLE
fix: Update DevelopmentBanner message and improve closure logic

### DIFF
--- a/client/src/components/ui/DevelopmentBanner.tsx
+++ b/client/src/components/ui/DevelopmentBanner.tsx
@@ -7,25 +7,31 @@ interface DevelopmentBannerProps {
 }
 
 const DevelopmentBanner: React.FC<DevelopmentBannerProps> = ({ 
-  message = "🚧 Portfolio under development - some features may be incomplete 🚧" 
+  message = "⚠️ Portfolio under development - some features may be incomplete!" 
 }) => {
   const [isVisible, setIsVisible] = useState(true);
-  
-  // Check if the banner was closed before
+    // Check if the banner was closed before and if the closure is still valid
   useEffect(() => {
-    const bannerClosed = localStorage.getItem('dev-banner-closed');
-    if (bannerClosed) {
-      setIsVisible(false);
+    const bannerClosedExpiry = localStorage.getItem('dev-banner-closed');
+    
+    if (bannerClosedExpiry) {
+      const expiryTime = parseInt(bannerClosedExpiry, 10);
+      const now = Date.now();
+      
+      // If the expiry time is in the future, keep the banner hidden
+      if (now < expiryTime) {
+        setIsVisible(false);
+      } else {
+        // If expired, remove from localStorage
+        localStorage.removeItem('dev-banner-closed');
+      }
     }
   }, []);
-  
-  const closeBanner = () => {
+    const closeBanner = () => {
     setIsVisible(false);
     // Remember the choice for 24 hours
-    localStorage.setItem('dev-banner-closed', 'true');
-    setTimeout(() => {
-      localStorage.removeItem('dev-banner-closed');
-    }, 24 * 60 * 60 * 1000);
+    const expiryTime = Date.now() + (24 * 60 * 60 * 1000);
+    localStorage.setItem('dev-banner-closed', expiryTime.toString());
   };
   
   return (


### PR DESCRIPTION
This pull request updates the `DevelopmentBanner` component to improve the handling of its visibility state by introducing an expiration mechanism for its closure. The key changes include refining the logic for storing and validating the banner's closed state in `localStorage`.

### Improvements to `DevelopmentBanner` visibility logic:

* Updated the default `message` property to include a more concise and consistent warning icon and text. (`client/src/components/ui/DevelopmentBanner.tsx`, [client/src/components/ui/DevelopmentBanner.tsxL10-R34](diffhunk://#diff-524c74efb5f1afd079f1bfaec99f73714f3ea026298341ee89e627c8fb33b203L10-R34))
* Enhanced the `useEffect` hook to check if the banner's closure expiration is still valid. If expired, the `localStorage` entry is removed to allow the banner to reappear. (`client/src/components/ui/DevelopmentBanner.tsx`, [client/src/components/ui/DevelopmentBanner.tsxL10-R34](diffhunk://#diff-524c74efb5f1afd079f1bfaec99f73714f3ea026298341ee89e627c8fb33b203L10-R34))
* Modified the `closeBanner` function to store the exact expiration timestamp (24 hours from the closure time) in `localStorage`, replacing the previous implementation that relied on a timeout. (`client/src/components/ui/DevelopmentBanner.tsx`, [client/src/components/ui/DevelopmentBanner.tsxL10-R34](diffhunk://#diff-524c74efb5f1afd079f1bfaec99f73714f3ea026298341ee89e627c8fb33b203L10-R34))