### PR TITLE
fix: Comment out WhatsApp link in ContactSection component

### DIFF
--- a/client/src/components/sections/ContactSection.tsx
+++ b/client/src/components/sections/ContactSection.tsx
@@ -184,7 +184,7 @@ const ContactSection: React.FC = () => {
                       <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
                     </svg>
                   </a>
-                  <a
+                  {/* <a
                     href={import.meta.env.VITE_WHATSAPP_URL}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -194,7 +194,7 @@ const ContactSection: React.FC = () => {
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path>
                     </svg>
-                  </a>
+                  </a> */}
                 </div>
               </div>
             </div>
@@ -280,8 +280,8 @@ const ContactSection: React.FC = () => {
                   type="submit"
                   disabled={isSubmitting || !captchaToken}
                   className={`w-full flex items-center justify-center px-6 py-3 rounded-lg font-medium transition-colors ${isSubmitting || !captchaToken
-                      ? 'bg-primary/70 cursor-not-allowed'
-                      : 'bg-primary hover:bg-primary-dark'
+                    ? 'bg-primary/70 cursor-not-allowed'
+                    : 'bg-primary hover:bg-primary-dark'
                     } text-white`}
                 >
                   {isSubmitting ? (


### PR DESCRIPTION
This pull request updates the `ContactSection` component in `ContactSection.tsx` to temporarily disable the WhatsApp contact link by commenting it out. No other functionality is affected.

Key change:

* Commented out the `<a>` tag that renders a clickable WhatsApp link, effectively disabling it while keeping the code intact for potential future use. (`client/src/components/sections/ContactSection.tsx`, [[1]](diffhunk://#diff-cfb67b50ec823e14fb3049af3ddf7cdd74188d53ae39c369bdec780ebadfb376L187-R187) [[2]](diffhunk://#diff-cfb67b50ec823e14fb3049af3ddf7cdd74188d53ae39c369bdec780ebadfb376L197-R197)