### PR TITLE
fix: Comment out Facebook link in ContactSection for maintenance

### DIFF
--- a/client/src/components/sections/ContactSection.tsx
+++ b/client/src/components/sections/ContactSection.tsx
@@ -162,7 +162,8 @@ const ContactSection: React.FC = () => {
                   </a>
 
                   <a
-                    href={import.meta.env.VITE_FACEBOOK_URL}
+                    // href={import.meta.env.VITE_FACEBOOK_URL}
+                    href="#"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="p-3 bg-card hover:bg-primary text-foreground hover:text-white rounded-full transition-colors shadow-sm"


### PR DESCRIPTION
This pull request includes a small change to the `ContactSection` component. The change comments out the use of the `VITE_FACEBOOK_URL` environment variable for the Facebook link and replaces it with a placeholder `"#"` URL.