### PR TITLE
fix: Add 'Languages' category to skills management and validation

### DIFF
--- a/client/src/components/admin/skills/SkillsAdmin.tsx
+++ b/client/src/components/admin/skills/SkillsAdmin.tsx
@@ -189,6 +189,7 @@ const SkillsAdmin: React.FC<SkillsAdminProps> = ({ token }) => {
     'Backend', 
     'Database', 
     'DevOps', 
+    'Languages',
     'Design', 
     'Other'
   ];

--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -8,7 +8,7 @@ import { Loader2 } from 'lucide-react';
 // Empty array for skills
 const fallbackSkills: Skill[] = [];
 
-const categories: SkillCategory[] = ['Frontend', 'Backend', 'Database', 'DevOps', 'Design', 'Other'];
+const categories: SkillCategory[] = ['Frontend', 'Backend', 'Database', 'DevOps', 'Languages', 'Design', 'Other'];
 
 const SkillsSection: React.FC = () => {
   const [activeCategory, setActiveCategory] = useState<SkillCategory | 'All'>('All');

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -17,6 +17,7 @@ export type SkillCategory =
   | 'Backend' 
   | 'Database' 
   | 'DevOps' 
+  | 'Languages'
   | 'Design' 
   | 'Other';
 

--- a/server/models/Skill.js
+++ b/server/models/Skill.js
@@ -9,7 +9,7 @@ const skillSchema = new mongoose.Schema({
   category: {
     type: String,
     required: [true, 'Category is required'],
-    enum: ['Frontend', 'Backend', 'Database', 'DevOps', 'Design', 'Other'],
+    enum: ['Frontend', 'Backend', 'Database', 'DevOps', 'Languages', 'Design', 'Other'],
     trim: true
   },
   proficiency: {

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -29,7 +29,7 @@ router.post('/', [
   [
     check('name', 'Skill name is required').not().isEmpty(),
     check('category', 'Category is required').isIn([
-      'Frontend', 'Backend', 'Database', 'DevOps', 'Design', 'Other'
+      'Frontend', 'Backend', 'Database', 'DevOps', 'Languages', 'Design', 'Other'
     ]),
     check('proficiency', 'Proficiency must be a number between 1 and 10').isInt({ min: 1, max: 10 }),
     check('icon', 'Icon reference is required').not().isEmpty()
@@ -73,7 +73,7 @@ router.put('/:id', [
   [
     check('name', 'Skill name is required').optional().not().isEmpty(),
     check('category', 'Invalid category').optional().isIn([
-      'Frontend', 'Backend', 'Database', 'DevOps', 'Design', 'Other'
+      'Frontend', 'Backend', 'Database', 'DevOps', 'Languages', 'Design', 'Other'
     ]),
     check('proficiency', 'Proficiency must be a number between 1 and 10')
       .optional()


### PR DESCRIPTION
This pull request introduces a new `Languages` category to the skills management system, updating both the frontend and backend to support it. The changes ensure consistent handling of the new category across the application.

### Frontend Updates:
* Added `Languages` to the `categories` array in `SkillsAdmin` and `SkillsSection` components to reflect the new category in the UI. (`client/src/components/admin/skills/SkillsAdmin.tsx` - [[1]](diffhunk://#diff-52175a8fcc06edc7a5652fc7655a48cba69ff6ed199d0997e2593ac5897c2a68R192) `client/src/components/sections/SkillsSection.tsx` - [[2]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdL11-R11)
* Updated the `SkillCategory` type definition to include `Languages`. (`client/src/types.ts` - [client/src/types.tsR20](diffhunk://#diff-e25af2d52bc6f544f873bd9732143170829c944d51a8297a3ac9fd206d0c2ad6R20))

### Backend Updates:
* Updated the `category` field in the `Skill` model to include `Languages` as a valid enum value. (`server/models/Skill.js` - [server/models/Skill.jsL12-R12](diffhunk://#diff-9c8b18923c13364a2cd4c2eec9acc8f77a4d415b7e457a23c86554994b718536L12-R12))
* Modified the validation logic in the `POST` and `PUT` routes for skills to recognize `Languages` as a valid category. (`server/routes/skills.js` - [[1]](diffhunk://#diff-c02facbdc397e771c5de39cf05c03ddaf6e55f47eb16fdbaffad491256e85ff3L32-R32) [[2]](diffhunk://#diff-c02facbdc397e771c5de39cf05c03ddaf6e55f47eb16fdbaffad491256e85ff3L76-R76)