### PR TITLE
fix: Add trust proxy setting for reverse proxy support

### DIFF
--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -4,7 +4,9 @@ const rateLimit = require('express-rate-limit');
 exports.globalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // limit each IP to 100 requests per windowMs
-  message: { error: 'Too many requests, please try again later' }
+  message: { error: 'Too many requests, please try again later' },
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 });
 
 // Not found middleware

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,10 @@ const { globalLimiter, notFound, errorHandler } = require('./middleware/errorHan
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+// Trust proxy - important for Railway/Heroku/etc. that use reverse proxies
+// This ensures that X-Forwarded-For headers are trusted for determining client IP
+app.set('trust proxy', 1);
+
 // Security Middleware
 app.use(helmet()); // Set security headers
 app.use(xss()); // Prevent XSS attacks


### PR DESCRIPTION
This pull request enhances the server's rate-limiting middleware and adds configuration to support reverse proxies. These changes improve security, compliance with modern standards, and compatibility with hosting platforms like Railway or Heroku.

### Enhancements to rate-limiting middleware:
* [`server/middleware/errorHandler.js`](diffhunk://#diff-7dd6dbc37dfd811fcf7164d2b60849651997f679f5ba3eb44376be410e3681d4L7-R9): Updated the rate limiter to include `standardHeaders: true` for returning rate limit information in `RateLimit-*` headers and `legacyHeaders: false` to disable outdated `X-RateLimit-*` headers.

### Support for reverse proxies:
* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R22-R25): Added `app.set('trust proxy', 1)` to trust `X-Forwarded-For` headers, ensuring proper client IP detection when using reverse proxies.