### PR TITLE
fix: Ensure 'Languages' category is included in skill categories and …

### DIFF
--- a/client/src/components/admin/skills/SkillsAdmin.tsx
+++ b/client/src/components/admin/skills/SkillsAdmin.tsx
@@ -183,7 +183,6 @@ const SkillsAdmin: React.FC<SkillsAdminProps> = ({ token }) => {
     };
     reader.readAsDataURL(file);
   };
-
   const skillCategories: SkillCategory[] = [
     'Frontend', 
     'Backend', 
@@ -193,6 +192,9 @@ const SkillsAdmin: React.FC<SkillsAdminProps> = ({ token }) => {
     'Design', 
     'Other'
   ];
+  
+  // Debug log to check if Languages is included
+  console.log('Available skill categories:', skillCategories);
 
   return (
     <div className="bg-card rounded-lg shadow-md p-6 border border-border/50">

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -17,7 +17,7 @@ export type SkillCategory =
   | 'Backend' 
   | 'Database' 
   | 'DevOps' 
-  | 'Languages'
+  | 'Languages' 
   | 'Design' 
   | 'Other';
 


### PR DESCRIPTION
This pull request introduces a minor debugging enhancement to the `SkillsAdmin` component in `client/src/components/admin/skills/SkillsAdmin.tsx`. A debug log was added to output the available skill categories for troubleshooting purposes.

Debugging improvement:

* [`client/src/components/admin/skills/SkillsAdmin.tsx`](diffhunk://#diff-52175a8fcc06edc7a5652fc7655a48cba69ff6ed199d0997e2593ac5897c2a68R196-R198): Added a `console.log` statement to display the `skillCategories` array, aiding in verifying its contents during runtime.…add debug log