### PR TITLE
fix: Remove comment about using Java icon for JavaFX in iconMap

### DIFF
--- a/client/src/components/ui/iconMap.tsx
+++ b/client/src/components/ui/iconMap.tsx
@@ -38,7 +38,7 @@ export const iconMap: Record<string, React.ComponentType<{ className?: string }>
     bootstrap: FaBootstrap,
     java: FaJava,
     python: FaPython,
-    javafx: FaJava, // Using Java icon for JavaFX since SiJavafx doesn't exist
+    javafx: FaJava,
     c: SiC,
     'c++': SiCplusplus,
     'c#': SiSharp,
@@ -47,5 +47,5 @@ export const iconMap: Record<string, React.ComponentType<{ className?: string }>
     wordpress: SiWordpress,
     twilio: SiTwilio,
     // Add a default icon
-    default: FaCode
+    // default: FaCode
 };


### PR DESCRIPTION
This pull request makes minor adjustments to the `iconMap` in `client/src/components/ui/iconMap.tsx`. These changes include removing unused comments and disabling the default icon mapping.

Changes to `iconMap`:

* Removed the comment explaining the use of the Java icon for JavaFX, as it was redundant.
* Disabled the default icon mapping by commenting out the `default: FaCode` line.