### PR TITLE
fix: Remove commented-out default icon in iconMap

### DIFF
--- a/client/src/components/ui/iconMap.tsx
+++ b/client/src/components/ui/iconMap.tsx
@@ -47,5 +47,5 @@ export const iconMap: Record<string, React.ComponentType<{ className?: string }>
     wordpress: SiWordpress,
     twilio: SiTwilio,
     // Add a default icon
-    // default: FaCode 
+    default: FaCode
 };


### PR DESCRIPTION
This pull request includes a minor change to the `iconMap` in `client/src/components/ui/iconMap.tsx`. The change removes a commented-out line and activates the `default` icon mapping to use `FaCode`.