### PR TITLE
fix: Update icon mapping for CSS to use SiCss3 instead of FaCss3Alt

### DIFF
--- a/client/src/components/ui/iconMap.tsx
+++ b/client/src/components/ui/iconMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    SiApachetomcat, SiPhp, SiExpress, SiNodedotjs, SiSpringboot,
+    SiApachetomcat, SiPhp, SiCss3, SiExpress, SiNodedotjs, SiSpringboot,
     SiMongodb, SiMysql, SiCanva, SiFigma, SiAdobeillustrator, SiAdobephotoshop,
     SiVercel, SiRailway, SiTailwindcss, SiJavascript, SiChartdotjs,
     SiC, SiCplusplus, SiSharp, SiKotlin,
@@ -31,7 +31,7 @@ export const iconMap: Record<string, React.ComponentType<{ className?: string }>
     railway: SiRailway,
     docker: FaDocker,
     html: FaHtml5,
-    css: FaCss3Alt,
+    css: SiCss3,
     react: FaReact,
     tailwind: SiTailwindcss,
     javascript: SiJavascript,


### PR DESCRIPTION
This pull request updates the `iconMap` component in the `client/src/components/ui/iconMap.tsx` file to replace the CSS icon library and ensure consistency in the use of icons across the application.

### Icon library updates:
* Replaced `FaCss3Alt` with `SiCss3` in the `iconMap` export to standardize the CSS icon library.
* Added `SiCss3` to the list of imported icons, replacing the previous CSS icon library reference.