### PR TITLE
feat: Update Education model and routes to make description optional …

### DIFF
--- a/client/src/components/admin/education/EducationAdmin.tsx
+++ b/client/src/components/admin/education/EducationAdmin.tsx
@@ -13,7 +13,6 @@ const EducationAdmin: React.FC<EducationAdminProps> = ({ token }) => {
   const [error, setError] = useState<string | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingEducation, setEditingEducation] = useState<Education | null>(null);
-
   const [formData, setFormData] = useState<Omit<Education, 'id'>>({
     institution: '',
     title: '',
@@ -283,7 +282,7 @@ const EducationAdmin: React.FC<EducationAdminProps> = ({ token }) => {
                   placeholder="Type skill and press Enter"
                   className="flex-grow outline-none bg-transparent min-w-[180px] py-1"
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ',') {
+                    if (e.key === 'Enter') {
                       e.preventDefault();
                       const input = e.currentTarget;
                       const value = input.value.trim();
@@ -294,6 +293,20 @@ const EducationAdmin: React.FC<EducationAdminProps> = ({ token }) => {
                           skills: [...prev.skills, value]
                         }));
                         input.value = '';
+                      }
+                    }
+                  }}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    // Handle commas by splitting the input and adding as tags
+                    if (value.includes(',')) {
+                      const skillsToAdd = value.split(',').map(s => s.trim()).filter(s => s);
+                      if (skillsToAdd.length > 0) {
+                        setFormData(prev => ({
+                          ...prev,
+                          skills: [...prev.skills, ...skillsToAdd]
+                        }));
+                        e.target.value = '';
                       }
                     }
                   }}

--- a/server/models/Education.js
+++ b/server/models/Education.js
@@ -13,8 +13,8 @@ const educationSchema = new mongoose.Schema({
   },
   description: {
     type: String,
-    required: [true, 'Description is required'],
     trim: true
+    // Made description optional by removing required field
   },
   skills: {
     type: [String],

--- a/server/routes/education.js
+++ b/server/routes/education.js
@@ -23,11 +23,11 @@ router.get('/', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const education = await Education.findById(req.params.id);
-    
+
     if (!education) {
       return res.status(404).json({ msg: 'Education entry not found' });
     }
-    
+
     res.json(education);
   } catch (error) {
     console.error(error.message);
@@ -46,7 +46,7 @@ router.post('/', [
   [
     check('institution', 'Institution name is required').not().isEmpty(),
     check('title', 'Title is required').not().isEmpty(),
-    check('description', 'Description is required').not().isEmpty(),
+    // Description is optional, so we don't validate it here
     check('timeline.start', 'Start date is required').not().isEmpty()
   ]
 ], async (req, res) => {
@@ -100,7 +100,7 @@ router.put('/:id', [
 
   try {
     const education = await Education.findById(req.params.id);
-    
+
     if (!education) {
       return res.status(404).json({ msg: 'Education entry not found' });
     }
@@ -127,7 +127,7 @@ router.put('/:id', [
 router.delete('/:id', protect, async (req, res) => {
   try {
     const education = await Education.findById(req.params.id);
-    
+
     if (!education) {
       return res.status(404).json({ msg: 'Education entry not found' });
     }


### PR DESCRIPTION
This pull request introduces changes to both the client and server sides of the education administration feature. Key updates include improving the handling of skills input on the client side and making the `description` field optional on the server side.

### Client-side changes (EducationAdmin component):

* Removed the ability to use a comma as a trigger for adding skills in the `onKeyDown` event, limiting it to the Enter key. (`client/src/components/admin/education/EducationAdmin.tsx`, [client/src/components/admin/education/EducationAdmin.tsxL286-R285](diffhunk://#diff-885a9a6557650ea14ca2faf223d4ba5da565b6ac4101080a894e73272f91df91L286-R285))
* Added an `onChange` handler to process commas in the input field by splitting the text and adding multiple skills at once. (`client/src/components/admin/education/EducationAdmin.tsx`, [client/src/components/admin/education/EducationAdmin.tsxR299-R312](diffhunk://#diff-885a9a6557650ea14ca2faf223d4ba5da565b6ac4101080a894e73272f91df91R299-R312))

### Server-side changes:

* Made the `description` field optional by removing the `required` validation in the Mongoose schema. (`server/models/Education.js`, [server/models/Education.jsL16-R17](diffhunk://#diff-0093310e587ba120c5277b36738094842996f7fc84ed7741bfb8d6ca4c0775bcL16-R17))
* Updated the validation in the POST route to reflect that the `description` field is no longer required. (`server/routes/education.js`, [server/routes/education.jsL49-R49](diffhunk://#diff-65227916874b3ed673bd39844b1f184aae3d0e0aae9302a132cd37689ceeb016L49-R49))