### PR TITLE
fix: Correct package name casing and refine CORS origin fallback logic

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "RT-portfolio-server",
+  "name": "rt-portfolio-server",
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {

--- a/server/server.js
+++ b/server/server.js
@@ -43,7 +43,7 @@ app.use(cors({
     // Fallback to development origin if no origins are specified
     const originsToCheck = allowedOrigins.length > 0 
       ? allowedOrigins
-      : [process.env.CORS_ORIGIN || 'http://localhost:5173'];
+      : [process.env.CORS_ORIGIN];
     
     if (originsToCheck.indexOf(origin) !== -1 || !origin) {
       callback(null, true);


### PR DESCRIPTION
This pull request includes minor updates to the server codebase, focusing on standardizing naming conventions and modifying CORS configuration.

### Naming convention update:
* [`server/package.json`](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L2-R2): Updated the `name` field to use lowercase (`rt-portfolio-server`) to align with standard naming conventions.

### CORS configuration adjustment:
* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L46-R46): Removed the fallback to `'http://localhost:5173'` in the CORS configuration, ensuring that only the value of `process.env.CORS_ORIGIN` is used when `allowedOrigins` is empty.