### PR TITLE
fix: Adjust maximum description length for admin and section components

### DIFF
--- a/client/src/components/admin/projects/ProjectsAdmin.tsx
+++ b/client/src/components/admin/projects/ProjectsAdmin.tsx
@@ -6,7 +6,7 @@ import { Loader2, Plus, Pencil, Trash2, ChevronDown, ChevronUp } from 'lucide-re
 import toast from 'react-hot-toast';
 
 // Maximum description length before truncation (approximately 4 lines)
-const MAX_ADMIN_DESCRIPTION_LENGTH = 240;
+const MAX_ADMIN_DESCRIPTION_LENGTH = 260;
 
 interface ProjectsAdminProps {
   token: string | null;

--- a/client/src/components/sections/ProjectsSection.tsx
+++ b/client/src/components/sections/ProjectsSection.tsx
@@ -9,7 +9,7 @@ import { getProjects } from '../../services/api';
 const fallbackProjects: Project[] = [];
 
 // Maximum description length before truncation
-const MAX_DESCRIPTION_LENGTH = 210;
+const MAX_DESCRIPTION_LENGTH = 200;
 
 const ProjectsSection: React.FC = () => {
   const [activeTag, setActiveTag] = useState<string | 'All'>('All');


### PR DESCRIPTION
This pull request makes adjustments to description length limits in two different components to ensure consistent truncation behavior across the application.

Description length adjustments:

* [`client/src/components/admin/projects/ProjectsAdmin.tsx`](diffhunk://#diff-1f65c6b9f3afa1692c10c07b4f84d037c90c91b66d4cfae52fbe1cfd7efa9491L9-R9): Increased the maximum description length for admin projects from 240 to 260 characters.
* [`client/src/components/sections/ProjectsSection.tsx`](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573L12-R12): Reduced the maximum description length for projects in the public section from 210 to 200 characters.