### PR TITLE
fix: Update maximum description length for admin projects

### DIFF
--- a/client/src/components/admin/projects/ProjectsAdmin.tsx
+++ b/client/src/components/admin/projects/ProjectsAdmin.tsx
@@ -6,7 +6,7 @@ import { Loader2, Plus, Pencil, Trash2, ChevronDown, ChevronUp } from 'lucide-re
 import toast from 'react-hot-toast';
 
 // Maximum description length before truncation (approximately 4 lines)
-const MAX_ADMIN_DESCRIPTION_LENGTH = 260;
+const MAX_ADMIN_DESCRIPTION_LENGTH = 300;
 
 interface ProjectsAdminProps {
   token: string | null;


### PR DESCRIPTION
This pull request includes a minor adjustment to the `ProjectsAdmin` component. The change increases the maximum description length for truncation from 260 to 300 characters, allowing for slightly longer project descriptions in the admin interface.