### PR TITLE
feat: Implement bulk actions for contact messages including read/unre…

### DIFF
--- a/client/src/components/admin/contact/ContactAdmin.tsx
+++ b/client/src/components/admin/contact/ContactAdmin.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { getContactMessages, deleteContactMessage } from '../../../services/api';
-import { Loader2, Trash2, Mail, Calendar, X } from 'lucide-react';
+import { getContactMessages, deleteContactMessage, markMessageAsRead, toggleMessageReadStatus } from '../../../services/api';
+import { Loader2, Trash2, X, Circle, CheckCircle2 } from 'lucide-react';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -71,6 +71,7 @@ interface ContactMessage {
   title: string;
   message: string;
   createdAt: string;
+  read: boolean;  // Added read property
 }
 
 const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
@@ -79,6 +80,9 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
   const [error, setError] = useState<string | null>(null);
   const [selectedMessage, setSelectedMessage] = useState<ContactMessage | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [filter, setFilter] = useState<'all' | 'unread' | 'read'>('all');
+  const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([]); // New state for bulk actions
+  const [isBulkActionLoading, setIsBulkActionLoading] = useState(false); // New loading state for bulk actions
 
   // Fetch contact messages
   useEffect(() => {
@@ -110,6 +114,7 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
 
     fetchMessages();
   }, [token]);
+
   const handleDelete = async (messageId: string) => {
     if (!token) {
       setError('Authentication token is missing. Please log in again.');
@@ -130,6 +135,7 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
       setSelectedMessage(messageToDelete);
     }
   };
+
   const confirmDelete = async () => {
     if (!token || !selectedMessage) return;
 
@@ -139,8 +145,7 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
       if (response.error) {
         setError(response.error);
         toast.error(`Failed to delete: ${response.error}`);
-      } else {
-        // Remove message from list
+      } else {        // Remove message from list
         setMessages(prev => prev.filter(message => message._id !== selectedMessage._id));
         toast.success('Message deleted successfully!');
       }
@@ -151,6 +156,61 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
     } finally {
       setLoading(false);
       setIsDialogOpen(false);
+    }
+  };
+
+  const handleMessageSelect = async (message: ContactMessage) => {
+    setSelectedMessage(message);
+
+    // If the message is unread, mark it as read
+    if (!message.read) {
+      try {
+        const response = await markMessageAsRead(message._id, token || '');
+        if (response.error) {
+          console.error('Failed to mark message as read:', response.error);
+        } else {
+          // Update the read status in the messages list
+          setMessages(prev =>
+            prev.map(msg =>
+              msg._id === message._id ? { ...msg, read: true } : msg
+            )
+          );
+          // Also update the selected message
+          setSelectedMessage(prev => prev ? { ...prev, read: true } : prev);
+        }
+      } catch (err) {
+        console.error('Error marking message as read:', err);
+      }
+    }
+  };
+
+  // Function to toggle read/unread status
+  const toggleReadStatus = async (message: ContactMessage) => {
+    try {
+      const newReadStatus = !message.read;
+      const response = await toggleMessageReadStatus(message._id, newReadStatus, token || '');
+
+      if (response.error) {
+        toast.error(`Failed to mark message as ${newReadStatus ? 'read' : 'unread'}`);
+        return;
+      }
+
+      // Update the message in our local state
+      setMessages(prev =>
+        prev.map(msg =>
+          msg._id === message._id ? { ...msg, read: newReadStatus } : msg
+        )
+      );
+
+      // If this is the currently selected message, update that too
+      if (selectedMessage && selectedMessage._id === message._id) {
+        setSelectedMessage({ ...selectedMessage, read: newReadStatus });
+      }
+
+      toast.success(`Message marked as ${newReadStatus ? 'read' : 'unread'}`);
+    } catch (err: any) {
+      console.error('Error toggling read status:', err);
+      toast.error(err.message || 'An error occurred');
     }
   };
 
@@ -165,13 +225,183 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
     });
   };
 
+  // Function to handle checking a message for bulk actions
+  const handleMessageCheckboxChange = (messageId: string) => {
+    setSelectedMessageIds(prev => {
+      if (prev.includes(messageId)) {
+        return prev.filter(id => id !== messageId);
+      } else {
+        return [...prev, messageId];
+      }
+    });
+  };
+
+  // Function to select/deselect all displayed messages
+  const handleSelectAllMessages = () => {
+    const filteredMessageIds = messages
+      .filter(message => {
+        if (filter === 'all') return true;
+        return filter === 'read' ? message.read : !message.read;
+      })
+      .map(message => message._id);
+
+    if (selectedMessageIds.length === filteredMessageIds.length) {
+      // If all are selected, deselect all
+      setSelectedMessageIds([]);
+    } else {
+      // Otherwise select all filtered messages
+      setSelectedMessageIds(filteredMessageIds);
+    }
+  };
+
+  // Function to mark multiple messages as read/unread
+  const handleBulkReadStatus = async (markAsRead: boolean) => {
+    if (!token) {
+      setError('Authentication token is missing. Please log in again.');
+      toast.error('Authentication token missing. Please log in again.');
+      return;
+    }
+
+    if (selectedMessageIds.length === 0) {
+      toast.info(`No messages selected to mark as ${markAsRead ? 'read' : 'unread'}`);
+      return;
+    }
+
+    setIsBulkActionLoading(true);
+    try {
+      // Create array of promises for each message status update
+      const updatePromises = selectedMessageIds.map(id =>
+        toggleMessageReadStatus(id, markAsRead, token)
+      );
+
+      await Promise.all(updatePromises);
+
+      // Update the messages in the state
+      setMessages(prev =>
+        prev.map(message =>
+          selectedMessageIds.includes(message._id)
+            ? { ...message, read: markAsRead }
+            : message
+        )
+      );
+
+      // If the currently selected message is in the list, update it too
+      if (selectedMessage && selectedMessageIds.includes(selectedMessage._id)) {
+        setSelectedMessage({ ...selectedMessage, read: markAsRead });
+      }
+
+      toast.success(`${selectedMessageIds.length} messages marked as ${markAsRead ? 'read' : 'unread'}`);
+
+      // Clear selection after the operation
+      setSelectedMessageIds([]);
+    } catch (err: any) {
+      console.error(`Error marking messages as ${markAsRead ? 'read' : 'unread'}:`, err);
+      toast.error(err.message || `An error occurred while marking messages as ${markAsRead ? 'read' : 'unread'}`);
+    } finally {
+      setIsBulkActionLoading(false);
+    }
+  };
+
+  // Function to handle bulk delete
+  const handleBulkDelete = async () => {
+    if (!token) {
+      setError('Authentication token is missing. Please log in again.');
+      toast.error('Authentication token missing. Please log in again.');
+      return;
+    }
+
+    if (selectedMessageIds.length === 0) {
+      toast.info('No messages selected for deletion');
+      return;
+    }
+
+    setIsBulkActionLoading(true);
+    try {
+      // Perform deletion for each selected message
+      const deletePromises = selectedMessageIds.map(id => deleteContactMessage(id, token));
+      await Promise.all(deletePromises);
+
+      // Filter out the deleted messages from the state
+      setMessages(prev => prev.filter(message => !selectedMessageIds.includes(message._id)));
+
+      // If the currently selected message is deleted, clear the selection
+      if (selectedMessage && selectedMessageIds.includes(selectedMessage._id)) {
+        setSelectedMessage(null);
+      }
+
+      toast.success('Selected messages deleted successfully!');
+
+      // Clear selection after deletion
+      setSelectedMessageIds([]);
+    } catch (err: any) {
+      console.error('Error deleting messages:', err);
+      toast.error(err.message || 'An error occurred while deleting messages');
+    } finally {
+      setIsBulkActionLoading(false);
+    }
+  };
+
+  // Get filtered messages based on current filter
+  const filteredMessages = messages.filter(message => {
+    if (filter === 'all') return true;
+    return filter === 'read' ? message.read : !message.read;
+  });
+
+  // Calculate message statistics
+  const totalMessages = messages.length;
+  const unreadCount = messages.filter(m => !m.read).length;
+  const readCount = totalMessages - unreadCount;
+
   return (
     <div className="bg-card rounded-lg shadow-md p-6 border border-border/50">
-      <h2 className="text-xl font-bold mb-6">Contact Messages</h2>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-bold">Contact Messages</h2>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-xs px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full">{unreadCount} Unread</span>
+            <span className="text-xs px-2 py-1 bg-green-100 text-green-800 rounded-full">{readCount} Read</span>
+          </div>
+        </div>
+      </div>
 
       {error && (
         <div className="p-3 mb-4 bg-red-500/10 border border-red-500/30 rounded-lg text-red-500 text-sm">
           {error}
+        </div>
+      )}
+
+      {selectedMessageIds.length > 0 && (
+        <div className="p-3 mb-4 bg-primary/10 border border-primary/30 rounded-lg flex flex-wrap items-center gap-2 text-sm">
+          <span>{selectedMessageIds.length} messages selected</span>
+          <div className="ml-auto flex gap-2">
+            <button
+              onClick={() => handleBulkReadStatus(true)}
+              className="px-3 py-1 rounded bg-green-500 text-white text-xs font-medium hover:bg-green-600 transition-colors"
+              disabled={isBulkActionLoading}
+            >
+              Mark Read
+            </button>
+            <button
+              onClick={() => handleBulkReadStatus(false)}
+              className="px-3 py-1 rounded bg-yellow-500 text-white text-xs font-medium hover:bg-yellow-600 transition-colors"
+              disabled={isBulkActionLoading}
+            >
+              Mark Unread
+            </button>
+            <button
+              onClick={handleBulkDelete}
+              className="px-3 py-1 rounded bg-red-500 text-white text-xs font-medium hover:bg-red-600 transition-colors"
+              disabled={isBulkActionLoading}
+            >
+              Delete
+            </button>
+            <button
+              onClick={() => setSelectedMessageIds([])}
+              className="px-3 py-1 rounded bg-background text-foreground text-xs font-medium border border-border hover:bg-background/80 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
 
@@ -183,8 +413,36 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Messages list */}
           <div className="md:col-span-1 border-r border-border/30 pr-4">
-            <div className="mb-4 font-medium text-foreground/70">
-              {messages.length} {messages.length === 1 ? 'Message' : 'Messages'}
+            <div className="flex justify-between items-center mb-4">
+              <div className="font-medium text-foreground/70 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 text-primary border-border rounded cursor-pointer"
+                  checked={filteredMessages.length > 0 && selectedMessageIds.length === filteredMessages.length}
+                  onChange={handleSelectAllMessages}
+                  aria-label="Select all messages"
+                />
+                <span>{messages.length} {messages.length === 1 ? 'Message' : 'Messages'}</span>
+                {messages.filter(m => !m.read).length > 0 && (
+                  <span className="bg-primary text-white text-xs px-2 py-0.5 rounded-full">
+                    {messages.filter(m => !m.read).length} unread
+                  </span>
+                )}
+              </div>
+
+              <div>
+                <select
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value as 'all' | 'unread' | 'read')}
+                  className="bg-background border border-border/50 rounded px-2 py-1 text-sm"
+                  aria-label="Filter messages"
+                  title="Filter messages"
+                >
+                  <option value="all">All</option>
+                  <option value="unread">Unread</option>
+                  <option value="read">Read</option>
+                </select>
+              </div>
             </div>
 
             {messages.length === 0 ? (
@@ -193,20 +451,55 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
               </div>
             ) : (
               <div className="space-y-2 max-h-96 overflow-y-auto pr-2">
-                {messages.map(message => (
+                {filteredMessages.map(message => (
                   <div
                     key={message._id}
-                    onClick={() => setSelectedMessage(message)}
-                    className={`p-3 rounded-lg cursor-pointer transition-colors ${selectedMessage?._id === message._id
-                      ? 'bg-primary/10 border-primary/30'
-                      : 'hover:bg-background border-transparent'
-                      } border`}
+                    className={`p-4 rounded-lg border transition-all flex flex-col gap-2 ${selectedMessage?._id === message._id
+                        ? 'bg-primary/10 border-primary'
+                        : 'bg-background border-border'
+                      }`}
                   >
-                    <div className="font-medium truncate">{message.name}</div>
-                    <div className="text-sm text-foreground/70 truncate">{message.title}</div>
-                    <div className="text-xs text-foreground/60 flex items-center gap-1 mt-1">
-                      <Calendar size={12} />
-                      {new Date(message.createdAt).toLocaleDateString()}
+                    <div className="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        className="mt-1 h-4 w-4 text-primary border-border rounded cursor-pointer"
+                        checked={selectedMessageIds.includes(message._id)}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          handleMessageCheckboxChange(message._id);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                        aria-label={`Select message from ${message.name}`}
+                      />
+                      <div className="flex-1 cursor-pointer" onClick={() => handleMessageSelect(message)}>
+                        <div className="flex justify-between items-start">
+                          <div>
+                            <p className="text-sm font-medium text-foreground">{message.title}</p>
+                            <p className="text-xs text-foreground/70">{message.name} - {formatDate(message.createdAt)}</p>
+                          </div>
+                          <div className="flex-shrink-0">
+                            <button
+                              onClick={(e) => { e.stopPropagation(); handleDelete(message._id); }}
+                              className="p-2 rounded-full hover:bg-red-500/10 transition-colors"
+                              aria-label="Delete message"
+                            >
+                              <Trash2 className="h-5 w-5 text-red-500" />
+                            </button>
+                          </div>
+                        </div>
+                        <div className="flex gap-2 text-xs mt-2">
+                          <span className={`px-3 py-1 rounded-full font-semibold ${message.read ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
+                            {message.read ? 'Read' : 'Unread'}
+                          </span>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); toggleReadStatus(message); }}
+                            className="ml-auto px-3 py-1 rounded-full bg-primary text-white text-xs font-semibold hover:bg-primary/90 transition-colors"
+                            aria-label={message.read ? 'Mark as unread' : 'Mark as read'}
+                          >
+                            {message.read ? 'Mark as Unread' : 'Mark as Read'}
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 ))}
@@ -214,64 +507,66 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
             )}
           </div>
 
-          {/* Message details */}
-          <div className="md:col-span-2 pl-0 md:pl-4">
+          {/* Message details panel */}
+          <div className="md:col-span-2 pl-4">
             {selectedMessage ? (
-              <div>
-                <div className="bg-background p-4 rounded-lg mb-4">
-                  <div className="flex justify-between items-start mb-4">
-                    <h3 className="text-xl font-bold">{selectedMessage.title}</h3>
+              <div className="bg-background p-4 rounded-lg shadow-md border border-border/50">
+                <div className="flex justify-between items-center mb-4">
+                  <div>
+                    <h3 className="text-lg font-semibold text-foreground">{selectedMessage.title}</h3>
+                    <p className="text-sm text-foreground/70">{selectedMessage.name} - {formatDate(selectedMessage.createdAt)}</p>
+                  </div>
+                  <div className="flex-shrink-0">
                     <button
-                      className="text-red-500 hover:text-red-600"
-                      onClick={() => handleDelete(selectedMessage._id)}
+                      onClick={(e) => { e.stopPropagation(); handleDelete(selectedMessage._id); }}
+                      className="p-2 rounded-full hover:bg-red-500/10 transition-colors"
                       aria-label="Delete message"
                     >
-                      <Trash2 size={18} />
+                      <Trash2 className="h-5 w-5 text-red-500" />
                     </button>
                   </div>
-
+                </div>
+                <div className="mb-2">
                   <div className="flex items-center gap-2 mb-2">
-                    <span className="font-medium">{selectedMessage.name}</span>
-                  </div>
-
-                  <div className="flex items-center gap-1 text-foreground/70 text-sm mb-4">
-                    <Mail size={14} />
-                    <a href={`mailto:${selectedMessage.email}`} className="hover:text-primary">
+                    <span className={`px-3 py-1 rounded-full font-semibold text-xs ${selectedMessage.read ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
+                      {selectedMessage.read ? 'Read' : 'Unread'}
+                    </span>
+                    <span className="text-xs text-foreground/70">
                       {selectedMessage.email}
-                    </a>
+                    </span>
                   </div>
+                  <p className="text-sm text-foreground/90">{selectedMessage.message}</p>
+                </div>
 
-                  <div className="text-xs text-foreground/60 mb-4">
-                    Received: {formatDate(selectedMessage.createdAt)}
-                  </div>
-
-                  <div className="bg-card p-4 rounded-lg border border-border/50">
-                    <p className="whitespace-pre-line">{selectedMessage.message}</p>
-                  </div>
-
-                  <div className="mt-4 flex justify-end">
-                    <a
-                      href={`mailto:${selectedMessage.email}`}
-                      className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors flex items-center gap-1"
-                    >
-                      <Mail size={16} />
-                      Reply
-                    </a>
-                  </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setIsDialogOpen(true)}
+                    className="flex-1 px-4 py-2 rounded-md bg-red-500 text-white text-sm font-semibold hover:bg-red-600 transition-colors flex items-center justify-center gap-2"
+                  >
+                    <Trash2 className="h-4 w-4" /> Delete Message
+                  </button>
+                  <button
+                    onClick={() => toggleReadStatus(selectedMessage)}
+                    className={`flex-1 px-4 py-2 rounded-md text-sm font-semibold transition-colors flex items-center justify-center gap-2 ${selectedMessage.read
+                        ? 'bg-yellow-500 hover:bg-yellow-600 text-white'
+                        : 'bg-green-500 hover:bg-green-600 text-white'
+                      }`}
+                  >
+                    {selectedMessage.read
+                      ? <><Circle className="h-4 w-4" /> Mark as Unread</>
+                      : <><CheckCircle2 className="h-4 w-4" /> Mark as Read</>
+                    }
+                  </button>
                 </div>
               </div>
             ) : (
-              <div className="flex flex-col items-center justify-center h-64 text-foreground/50">
-                <Mail size={48} className="mb-4 opacity-20" />
-                <p>Select a message to view details</p>
+              <div className="text-center py-12 text-foreground/60">
+                Select a message to view details.
               </div>
             )}
           </div>
         </div>
       )}
-
-      {/* Toast notifications container */}
-      <ToastContainer position="top-right" autoClose={5000} hideProgressBar={false} />
 
       {/* Delete confirmation dialog */}
       <DeleteConfirmationDialog
@@ -280,6 +575,8 @@ const ContactAdmin: React.FC<ContactAdminProps> = ({ token }) => {
         onConfirm={confirmDelete}
         message={selectedMessage}
       />
+
+      <ToastContainer position="top-right" autoClose={5000} hideProgressBar={false} closeOnClick pauseOnHover draggable />
     </div>
   );
 };

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -588,6 +588,37 @@ export const getContactMessages = async (token: string): Promise<ApiResponse<any
   }
 };
 
+export const markMessageAsRead = async (messageId: string, token: string): Promise<ApiResponse<any>> => {
+  try {
+    // The backend already handles marking a message as read when accessed by ID
+    const response = await api.get(`/contact/${messageId}`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    return { data: response.data };
+  } catch (error: any) {
+    console.error('Error marking message as read:', error);
+    return {
+      data: {},
+      error: error.response?.data?.msg || 'Failed to mark message as read'
+    };
+  }
+};
+
+export const toggleMessageReadStatus = async (messageId: string, isRead: boolean, token: string): Promise<ApiResponse<any>> => {
+  try {
+    const response = await api.put(`/contact/${messageId}/status`, { read: isRead }, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    return { data: response.data };
+  } catch (error: any) {
+    console.error(`Error toggling message read status to ${isRead}:`, error);
+    return {
+      data: {},
+      error: error.response?.data?.msg || `Failed to mark message as ${isRead ? 'read' : 'unread'}`
+    };
+  }
+};
+
 export const deleteContactMessage = async (messageId: string, token: string): Promise<ApiResponse<{ msg: string }>> => {
   try {
     const response = await api.delete(`/contact/${messageId}`, {


### PR DESCRIPTION
This pull request introduces functionality to manage the read status of contact messages, including marking messages as read and toggling their read/unread status. It adds new API endpoints on the backend and corresponding methods on the frontend to interact with these endpoints.

### Backend Changes:
* **New API endpoint to toggle read status**: Added a `PUT /api/contact/:id/status` route to update the read status of a contact message. It validates the input, checks for the existence of the message, and updates its `read` property.

### Frontend Changes:
* **New method for marking a message as read**: Added the `markMessageAsRead` function in `client/src/services/api.ts` to fetch a message by ID and implicitly mark it as read.
* **New method for toggling read/unread status**: Added the `toggleMessageReadStatus` function in `client/src/services/api.ts` to explicitly update the `read` status of a message via the new backend endpoint.