### PR TITLE
fix: Update SVG viewBox for account settings icon to improve rendering

### DIFF
--- a/client/src/components/admin/AdminPanel.tsx
+++ b/client/src/components/admin/AdminPanel.tsx
@@ -214,7 +214,7 @@ const AdminPanel: React.FC = () => {
             title="Account Settings"
             aria-label="Account Settings"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
               <circle cx="12" cy="7" r="4"></circle>
             </svg>


### PR DESCRIPTION
This pull request includes a minor update to the `AdminPanel` component. The change modifies the `viewBox` attribute of the SVG used for the "Account Settings" icon, adjusting it from `0 0 20 20` to `0 0 24 24` for better scalability and alignment with design standards.