### PR TITLE
style: Update CORS allowed headers to include 'Pragma' and 'Expires'

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -60,7 +60,7 @@ app.use(cors({
     }
   }, credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control']
+  allowedHeaders: ['Content-Type', 'Authorization', 'Cache-Control', 'Pragma', 'Expires']
 }));
 app.use(express.json({ limit: '10kb' }));  // Limit JSON body size
 


### PR DESCRIPTION
This pull request includes a small update to the CORS configuration in `server/server.js`. The change adds two headers, `Pragma` and `Expires`, to the `allowedHeaders` list to ensure compatibility with caching-related requests.