### PR TITLE
style: Comment out debug logging for API requests to clean up console…

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -36,12 +36,12 @@ api.interceptors.request.use(
     };
 
     // Debug logging for all requests
-    console.log('========== API REQUEST START ==========');
-    console.log(`URL: ${config.baseURL}${config.url}`);
-    console.log(`Method: ${config.method?.toUpperCase()}`);
-    console.log('Headers:', config.headers);
-    console.log('Request Data:', config.data);
-    console.log('========== API REQUEST END ==========');    // Skills update debug log
+    // console.log('========== API REQUEST START ==========');
+    // console.log(`URL: ${config.baseURL}${config.url}`);
+    // console.log(`Method: ${config.method?.toUpperCase()}`);
+    // console.log('Headers:', config.headers);
+    // console.log('Request Data:', config.data);
+    // console.log('========== API REQUEST END ==========');    // Skills update debug log
     if (config.url?.startsWith('/skills/') && config.method === 'put') {
       console.log('🔄 Skill update request detected');
     }


### PR DESCRIPTION
This pull request includes a minor change to the `client/src/services/api.ts` file. The debug logging for all API requests has been commented out, leaving only the specific log for skill update requests active.

* [`client/src/services/api.ts`](diffhunk://#diff-ac12ccf4a992280fc6133152846dbaacba4f07ff21901b404635932d3cf94ce9L39-R44): Commented out general debug logging for all API requests while retaining the log for skill update requests.