### PR TITLE
feat: Add Service Worker cleanup modal and enhance toast notifications

### DIFF
--- a/client/src/components/ui/ServiceWorkerModal.tsx
+++ b/client/src/components/ui/ServiceWorkerModal.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, RefreshCw, CheckCircle, AlertCircle, Loader2, ArrowLeft, Trash2 } from 'lucide-react';
+
+interface ServiceWorkerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  status: {
+    message: string;
+    type: 'loading' | 'success' | 'error' | 'warning';
+    details?: string[];
+  };
+  onRefresh?: () => void;
+  onHomeRefresh?: () => void;
+  showRefreshButtons: boolean;
+}
+
+const ServiceWorkerModal: React.FC<ServiceWorkerModalProps> = ({
+  isOpen,
+  onClose,
+  status,
+  onRefresh,
+  onHomeRefresh,
+  showRefreshButtons
+}) => {
+  // Track animation state
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // Close handler with animation
+  const handleClose = () => {
+    setIsAnimating(true);
+    setTimeout(() => {
+      setIsAnimating(false);
+      onClose();
+    }, 300);
+  };
+
+  // Prevent scrolling when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Status icon based on the current state
+  const getStatusIcon = () => {
+    switch (status.type) {
+      case 'loading':
+        return <Loader2 className="h-6 w-6 animate-spin text-primary" />;
+      case 'success':
+        return <CheckCircle className="h-6 w-6 text-green-500" />;
+      case 'error':
+        return <AlertCircle className="h-6 w-6 text-red-500" />;
+      case 'warning':
+        return <AlertCircle className="h-6 w-6 text-amber-500" />;
+      default:
+        return <Loader2 className="h-6 w-6 animate-spin text-primary" />;
+    }
+  };
+
+  // Progress indicator - shows different stages of the cleanup
+  const getProgressIndicator = () => {
+    return (
+      <div className="flex flex-col space-y-2 w-full mt-2">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium">Cleanup Progress</span>
+        </div>
+        <div className="h-2 bg-background rounded-full overflow-hidden">
+          <motion.div
+            className={`h-full rounded-full ${
+              status.type === 'success' 
+                ? 'bg-green-500' 
+                : status.type === 'error'
+                ? 'bg-red-500'
+                : 'bg-primary'
+            }`}
+            initial={{ width: 0 }}
+            animate={{ 
+              width: status.type === 'loading' ? ['30%', '60%', '80%'] : '100%' 
+            }}
+            transition={{ 
+              duration: status.type === 'loading' ? 2 : 0.5,
+              ease: "easeInOut",
+              times: [0, 0.5, 1],
+              repeat: status.type === 'loading' ? Infinity : 0
+            }}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
+            onClick={handleClose}
+          />
+          
+          {/* Modal */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, y: 20 }}
+            transition={{ type: "spring", bounce: 0.3 }}
+            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md"
+          >
+            <div className="bg-card rounded-lg shadow-xl border border-border overflow-hidden">
+              {/* Header */}
+              <div className="p-4 border-b border-border flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Trash2 className="h-5 w-5 text-primary" />
+                  <h3 className="text-lg font-semibold">Service Worker Cleanup</h3>
+                </div>
+                <button 
+                  onClick={handleClose}
+                  className="p-1 hover:bg-muted rounded-full"
+                  aria-label="Close modal"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              
+              {/* Content */}
+              <div className="p-5">
+                <div className="flex items-center gap-3 mb-4">
+                  {getStatusIcon()}
+                  <div className="flex-1">
+                    <p className="font-medium">{status.message}</p>
+                    {getProgressIndicator()}
+                  </div>
+                </div>
+                
+                {/* Details */}
+                {status.details && status.details.length > 0 && (
+                  <div className="bg-card-foreground/5 p-3 rounded-md my-4">
+                    <h4 className="text-sm font-medium mb-2">Cleanup Details:</h4>
+                    <ul className="space-y-1.5">
+                      {status.details.map((detail, index) => (
+                        <li key={index} className="text-sm flex items-start gap-2">
+                          <div className="mt-0.5">
+                            {status.type === 'loading' ? (
+                              <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                            ) : status.type === 'success' ? (
+                              <div className="h-2 w-2 rounded-full bg-green-500" />
+                            ) : (
+                              <div className="h-2 w-2 rounded-full bg-amber-500" />
+                            )}
+                          </div>
+                          <span className="flex-1 text-foreground/80">{detail}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                
+                {/* Help text */}
+                <div className="mt-5 text-sm text-foreground/70">
+                  <p>This tool helps resolve the following issues:</p>
+                  <ul className="list-disc mt-2 pl-5 space-y-1">
+                    <li>CORS errors when refreshing pages</li>
+                    <li>Outdated cached content displaying incorrectly</li>
+                    <li>API connection problems</li>
+                    <li>Service worker conflicts</li>
+                  </ul>
+                </div>
+              </div>
+              
+              {/* Footer with actions */}
+              {showRefreshButtons && (
+                <div className="p-4 bg-card-foreground/5 border-t border-border">
+                  <div className="flex flex-col gap-3">
+                    {onRefresh && (
+                      <button
+                        onClick={onRefresh}
+                        className="flex items-center justify-center gap-2 bg-primary text-white p-2.5 rounded-md hover:bg-primary/90 transition-colors"
+                      >
+                        <RefreshCw className="h-4 w-4" />
+                        <span>Reload Current Page</span>
+                      </button>
+                    )}
+                    {onHomeRefresh && (
+                      <button
+                        onClick={onHomeRefresh}
+                        className="flex items-center justify-center gap-2 bg-background border border-border p-2.5 rounded-md hover:bg-muted transition-colors"
+                      >
+                        <ArrowLeft className="h-4 w-4" />
+                        <span>Return to Home Page</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ServiceWorkerModal;

--- a/client/src/components/utility/ServiceWorkerCleanup.tsx
+++ b/client/src/components/utility/ServiceWorkerCleanup.tsx
@@ -101,7 +101,8 @@ const ServiceWorkerCleanup: React.FC = () => {
                             </ul>
                         </div>
                     )}
-                </div>                {needsRefresh && (
+                </div>
+                {needsRefresh && (
                     <div className="flex flex-col space-y-3">
                         <button
                             onClick={handleRefresh}


### PR DESCRIPTION
This pull request introduces a new `ServiceWorkerModal` component to improve the user experience during service worker cleanup operations. The changes include implementing a modal-based interface for cleanup progress, updating the `Footer` component to integrate the modal, and ensuring backward compatibility with the existing toast notifications.

### New Feature: Service Worker Cleanup Modal
* Added a new `ServiceWorkerModal` component to display cleanup progress, status, and details in a modal interface. The modal supports various states (`loading`, `success`, `error`, `warning`) and includes actions for refreshing the page or returning to the home page. (`client/src/components/ui/ServiceWorkerModal.tsx`)

### Integration with Footer Component
* Updated the `Footer` component to manage the modal's state (`showModal`, `modalStatus`, `showRefreshButtons`) and handle service worker cleanup logic using the modal. The cleanup process now provides detailed progress updates and results through the modal. (`client/src/components/layout/Footer.tsx`) [[1]](diffhunk://#diff-313704bd49d96f6331d6c305f5382b3861ed48d2ee3e10a55c0284775f54423eR7) [[2]](diffhunk://#diff-313704bd49d96f6331d6c305f5382b3861ed48d2ee3e10a55c0284775f54423eR19-R171)

### Code Refinement
* Adjusted the `ServiceWorkerCleanup` utility component to ensure compatibility with the modal-based workflow while maintaining existing functionality. (`client/src/components/utility/ServiceWorkerCleanup.tsx`)