### PR TITLE
feat: Add tag expansion functionality in ProjectsSection for better v…

### DIFF
--- a/client/src/components/sections/ProjectsSection.tsx
+++ b/client/src/components/sections/ProjectsSection.tsx
@@ -15,7 +15,9 @@ const ProjectsSection: React.FC = () => {
   const [activeTag, setActiveTag] = useState<string | 'All'>('All');
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null); const [expandedDescriptions, setExpandedDescriptions] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [expandedDescriptions, setExpandedDescriptions] = useState<Record<string, boolean>>({});
+  const [expandedTags, setExpandedTags] = useState<Record<string, boolean>>({});
   const [ref, inView] = useInView({
     triggerOnce: true,
     threshold: 0.1,
@@ -50,10 +52,17 @@ const ProjectsSection: React.FC = () => {
 
     fetchProjects();
   }, []);
-
   // Toggle description expansion for a specific project
   const toggleDescription = (projectId: string) => {
     setExpandedDescriptions(prev => ({
+      ...prev,
+      [projectId]: !prev[projectId]
+    }));
+  };
+
+  // Toggle tag expansion for a specific project
+  const toggleTags = (projectId: string) => {
+    setExpandedTags(prev => ({
       ...prev,
       [projectId]: !prev[projectId]
     }));
@@ -152,7 +161,7 @@ const ProjectsSection: React.FC = () => {
                       <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-t from-black/80 via-black/40 to-transparent"></div>
                       {/* project cover image */}
                       <div className="absolute bottom-0 left-0 w-full p-4">
-                        <div className="flex flex-wrap gap-2 h-16 overflow-hidden">
+                        <div className={`flex flex-wrap gap-2 max-h-[4.25rem] overflow-hidden ${expandedTags[project.id] ? 'max-h-none' : ''}`}>
                           {project.tags.map((tag, idx) => (
                             <span
                               key={`${tag}-${idx}`}
@@ -162,6 +171,30 @@ const ProjectsSection: React.FC = () => {
                             </span>
                           ))}
                         </div>
+                        {project.tags.length > 4 && !expandedTags[project.id] && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleTags(project.id);
+                            }}
+                            className="absolute right-4 bottom-4 flex items-center justify-center w-6 h-6 bg-primary/90 text-white text-xs rounded-full shadow-sm"
+                            aria-label="Show more tags"
+                          >
+                            +{project.tags.length - 4}
+                          </button>
+                        )}
+                        {expandedTags[project.id] && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleTags(project.id);
+                            }}
+                            className="absolute right-4 bottom-4 flex items-center justify-center w-6 h-6 bg-primary/90 text-white text-xs rounded-full shadow-sm"
+                            aria-label="Show less tags"
+                          >
+                            <ChevronUp size={12} />
+                          </button>
+                        )}
                       </div>
                     </div>
 


### PR DESCRIPTION
This pull request introduces functionality to toggle the visibility of project tags in the `ProjectsSection` component. The changes include adding state management for expanded tags, implementing a toggle function, and updating the UI to display "Show more" and "Show less" buttons based on the number of tags.

### New functionality for tag expansion:

* Added a new state, `expandedTags`, to manage the visibility of expanded tags for each project. (`client/src/components/sections/ProjectsSection.tsx`, [client/src/components/sections/ProjectsSection.tsxL18-R20](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573L18-R20))
* Implemented the `toggleTags` function to toggle the expanded state for project tags. (`client/src/components/sections/ProjectsSection.tsx`, [client/src/components/sections/ProjectsSection.tsxR63-R70](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R63-R70))

### UI updates for tag visibility:

* Updated the tag container's CSS classes to dynamically adjust its height based on the `expandedTags` state. (`client/src/components/sections/ProjectsSection.tsx`, [client/src/components/sections/ProjectsSection.tsxL155-R164](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573L155-R164))
* Added "Show more" and "Show less" buttons to toggle tag visibility, with appropriate click handlers and accessibility labels. (`client/src/components/sections/ProjectsSection.tsx`, [client/src/components/sections/ProjectsSection.tsxR174-R197](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R174-R197))