### PR TITLE
style: Adjust positioning of right fade gradient and scroll arrow in …

### DIFF
--- a/client/src/components/ui/ScrollableTagRow.tsx
+++ b/client/src/components/ui/ScrollableTagRow.tsx
@@ -94,14 +94,14 @@ const ScrollableTagRow: React.FC<ScrollableTagRowProps> = ({ tags, className = '
 
                 {/* Right fade gradient */}
                 {showRightArrow && (
-                    <div className="relative right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-card ml-[10px] to-transparent z-10 pointer-events-none" />
+                    <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-card to-transparent z-10 pointer-events-none" />
                 )}
             </div>
 
             {/* Right scroll arrow */}
             {showRightArrow && (
                 <button
-                    className="absolute right-0 z-10 flex items-center justify-center h-6 w-6 rounded-full bg-background/80 border border-primary/20 shadow-sm hover:bg-primary/10 transition-colors"
+                    className="relative right-0 z-10 flex items-center justify-center h-6 w-6 ml-[10px] rounded-full bg-background/80 border border-primary/20 shadow-sm hover:bg-primary/10 transition-colors"
                     onClick={scrollRight}
                     aria-label="Scroll tags right"
                 >


### PR DESCRIPTION
This pull request includes minor adjustments to the `ScrollableTagRow` component in `client/src/components/ui/ScrollableTagRow.tsx`. These changes refine the positioning and styling of the right fade gradient and scroll arrow elements.

Styling improvements:

* Updated the `Right fade gradient` element to use `absolute` positioning instead of `relative` for better alignment.
* Adjusted the `Right scroll arrow` element to include a left margin (`ml-[10px]`) for improved spacing.