### PR TITLE
Contact

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -2,38 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ruchira-portfolio.vercel.app/</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
+    <lastmod>2025-06-24T08:23:13.734Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://ruchira-portfolio.vercel.app/about</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
+    <loc>https://ruchira-portfolio.vercel.app/admin</loc>
+    <lastmod>2025-06-24T08:23:13.734Z</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://ruchira-portfolio.vercel.app/projects</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://ruchira-portfolio.vercel.app/skills</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://ruchira-portfolio.vercel.app/education</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://ruchira-portfolio.vercel.app/contact</loc>
-    <lastmod>2025-06-24T08:08:10.172Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -2,14 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ruchira-portfolio.vercel.app/</loc>
-    <lastmod>2025-06-24T08:23:13.734Z</lastmod>
+    <lastmod>2025-06-24T08:25:04.552Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://ruchira-portfolio.vercel.app/admin</loc>
-    <lastmod>2025-06-24T08:23:13.734Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tools/generate-sitemap.js
+++ b/tools/generate-sitemap.js
@@ -7,35 +7,17 @@ const SITE_URL = process.env.VITE_PORTFOLIO_URL || 'https://ruchira-portfolio.ve
 const PUBLIC_DIR = path.join(__dirname, '../client/public');
 
 // Define the site structure
+// Single page application - only the homepage and admin page
 const pages = [
   {
     url: '/',
-    changefreq: 'daily',
+    changefreq: 'daily', // Set to daily since you're making frequent changes during development
     priority: '1.0'
   },
   {
-    url: '/about',
+    url: '/admin',
     changefreq: 'daily',
-    priority: '0.8'
-  },
-  {
-    url: '/projects',
-    changefreq: 'daily',
-    priority: '0.8'
-  },
-  {
-    url: '/skills',
-    changefreq: 'daily',
-    priority: '0.8'
-  },  {
-    url: '/education',
-    changefreq: 'daily',
-    priority: '0.7'
-  },
-  {
-    url: '/contact',
-    changefreq: 'daily',
-    priority: '0.7'
+    priority: '0.5'
   }
 ];
 

--- a/tools/generate-sitemap.js
+++ b/tools/generate-sitemap.js
@@ -7,18 +7,14 @@ const SITE_URL = process.env.VITE_PORTFOLIO_URL || 'https://ruchira-portfolio.ve
 const PUBLIC_DIR = path.join(__dirname, '../client/public');
 
 // Define the site structure
-// Single page application - only the homepage and admin page
+// Single page application - only the homepage
 const pages = [
   {
     url: '/',
     changefreq: 'daily', // Set to daily since you're making frequent changes during development
     priority: '1.0'
-  },
-  {
-    url: '/admin',
-    changefreq: 'daily',
-    priority: '0.5'
   }
+  // Admin page removed for privacy/security
 ];
 
 // Generate sitemap XML


### PR DESCRIPTION
This pull request simplifies the sitemap generation for the portfolio website by transitioning to a single-page application model. It removes entries for individual subpages from the sitemap and updates the sitemap generation script accordingly.

### Sitemap simplification:

* [`client/public/sitemap.xml`](diffhunk://#diff-8384fe871a711d303307d34ce7b4bc455deb18d7d442ad32acaaea96673143d6L5-L38): Removed entries for subpages (`/about`, `/projects`, `/skills`, `/education`, `/contact`) and updated the `lastmod` timestamp for the homepage.

### Code adjustments for single-page application:

* [`tools/generate-sitemap.js`](diffhunk://#diff-16e431a694e2f61248ecc91c9b1eac9b5c064904c2cffd52b5ac0401c5943079R10-R17): Updated the `pages` array to include only the homepage, reflecting the single-page application structure. Removed subpage entries and added comments to explain the changes, including the removal of an admin page for privacy/security.