### PR TITLE
style: Adjust padding of toggle button in SocialSidebar for improved visual consistency

### DIFF
--- a/client/src/components/layout/SocialSidebar.tsx
+++ b/client/src/components/layout/SocialSidebar.tsx
@@ -82,7 +82,7 @@ const SocialSidebar: React.FC = () => {
       <motion.button
         onClick={toggleSidebar}
         className={`
-          p-[1px] 
+          p-[0px] 
           ${isExpanded ? 'bg-card/60' : 'bg-card/70'} 
           rounded-r-md 
           h-20 


### PR DESCRIPTION
This pull request includes a minor update to the `SocialSidebar` component. The padding for the motion button has been adjusted from `p-[1px]` to `p-[0px]` for improved styling consistency.