### PR TITLE
style: Update favicon links to include versioning for better cache management

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -26,8 +26,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
-  <link rel="icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico?v=2" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.ico?v=2" type="image/x-icon">
 </head>
 
 <body>


### PR DESCRIPTION
This pull request updates the favicon links in the `client/index.html` file to include a version query parameter for cache busting.

Changes to favicon links:

* [`client/index.html`](diffhunk://#diff-edfa4829c58ad696e48ab606527eabead1471963a743486a94b65fe215035814L29-R30): Updated the `href` attribute of the `<link rel="icon>` and `<link rel="shortcut icon>` tags to include `?v=2`, ensuring the favicon updates are reflected without relying on browser cache.