### PR TITLE
refactor: Simplify success message in ServiceWorkerModal and remove redundant instructions

### DIFF
--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -129,8 +129,7 @@ const Footer: React.FC = () => {
             'Successfully unregistered all service workers',
             'Cleared browser caches',
             'Removed stored API URLs',
-            'Ready to reload with fresh data',
-            'Please use one of the buttons below to refresh the page'
+            'Ready to reload with fresh data'
           ]
         });
       } else if (result && result.type === 'error') {

--- a/client/src/components/ui/ServiceWorkerModal.tsx
+++ b/client/src/components/ui/ServiceWorkerModal.tsx
@@ -171,6 +171,13 @@ const ServiceWorkerModal: React.FC<ServiceWorkerModalProps> = ({
                                                 <p>Click "Proceed with Cleanup" to continue or "Cancel" to exit</p>
                                             </div>
                                         )}
+                                        
+                                        {/* Instructions text for success state */}
+                                        {status.type === 'success' && (
+                                            <div className="mt-6 text-sm text-foreground/70 text-center">
+                                                <p>Please use one of the buttons below to refresh the page</p>
+                                            </div>
+                                        )}
                                     </div>
 
                                     {/* Footer with actions */}


### PR DESCRIPTION
This pull request makes adjustments to user-facing text related to service worker cleanup processes, ensuring consistency and clarity in messaging across components.

Text updates for service worker cleanup:

* [`client/src/components/layout/Footer.tsx`](diffhunk://#diff-313704bd49d96f6331d6c305f5382b3861ed48d2ee3e10a55c0284775f54423eL132-R132): Removed the instruction "Please use one of the buttons below to refresh the page" from the success message array.
* [`client/src/components/ui/ServiceWorkerModal.tsx`](diffhunk://#diff-ef669c064f6496c1a8b26cb44b7ef74a5d9f58ac9eed86c2c79430bf74f7c990R174-R180): Added the instruction "Please use one of the buttons below to refresh the page" as part of the success state in the modal, ensuring the text is displayed in a more contextual location.