### PR TITLE
style: Update fade overlays in ScrollableTagRow for improved visual effect and dark mode support

### DIFF
--- a/client/src/components/ui/ScrollableTagRow.tsx
+++ b/client/src/components/ui/ScrollableTagRow.tsx
@@ -73,8 +73,8 @@ const ScrollableTagRow: React.FC<ScrollableTagRowProps> = ({ tags, className = '
                 {/* Left fade overlay - improved with multiple layers for better visual effect */}
                 {showLeftArrow && (
                     <>
-                        <div className="absolute left-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-r from-card/80 via-card/50 to-transparent pointer-events-none" />
-                        <div className="absolute left-0 top-0 bottom-0 w-2 z-10 bg-card/90 pointer-events-none shadow-[2px_0px_4px_rgba(0,0,0,0.1)]" />
+                        <div className="absolute left-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-r from-gray-800/80 via-gray-800/50 to-transparent pointer-events-none dark:from-card/80 dark:via-card/50" />
+                        <div className="absolute left-0 top-0 bottom-0 w-2 z-10 bg-gray-800/90 pointer-events-none shadow-[2px_0px_4px_rgba(0,0,0,0.1)] dark:bg-card/90" />
                     </>
                 )}
 
@@ -96,8 +96,8 @@ const ScrollableTagRow: React.FC<ScrollableTagRowProps> = ({ tags, className = '
                 {/* Right fade overlay - improved with multiple layers for better visual effect */}
                 {showRightArrow && (
                     <>
-                        <div className="absolute right-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-l from-card/80 via-card/50 to-transparent pointer-events-none" />
-                        <div className="absolute right-0 top-0 bottom-0 w-2 z-10 bg-card/90 pointer-events-none shadow-[-2px_0px_4px_rgba(0,0,0,0.1)]" />
+                        <div className="absolute right-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-l from-gray-800/80 via-gray-800/50 to-transparent pointer-events-none dark:from-card/80 dark:via-card/50" />
+                        <div className="absolute right-0 top-0 bottom-0 w-2 z-10 bg-gray-800/90 pointer-events-none shadow-[-2px_0px_4px_rgba(0,0,0,0.1)] dark:bg-card/90" />
                     </>
                 )}
             </div>


### PR DESCRIPTION
This pull request updates the visual styling of the `ScrollableTagRow` component to improve compatibility with dark mode and enhance the fade overlay effects. The changes focus on refining the appearance of both the left and right fade overlays.

Dark mode compatibility improvements:

* [`client/src/components/ui/ScrollableTagRow.tsx`](diffhunk://#diff-29e117f1f721403d817fe64cc28ef7a678743d687a857626444d7b2126f37eefL76-R77): Updated the left fade overlay to use `gray-800` colors for light mode and `card` colors for dark mode, ensuring consistent visual effects across themes.
* [`client/src/components/ui/ScrollableTagRow.tsx`](diffhunk://#diff-29e117f1f721403d817fe64cc28ef7a678743d687a857626444d7b2126f37eefL99-R100): Updated the right fade overlay with similar adjustments to use `gray-800` for light mode and `card` colors for dark mode, maintaining uniformity in dark mode styling.