### PR TITLE
refactor: Adjust padding in ConfirmationModal content for better alignment

### DIFF
--- a/client/src/components/ui/ConfirmationModal.tsx
+++ b/client/src/components/ui/ConfirmationModal.tsx
@@ -73,7 +73,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
                 </button>
                 
                 {/* Content */}
-                <div className="pt-7 pb-5 px-5 flex flex-col items-center">
+                <div className="pt-7 pb-5 px-[22px] flex flex-col items-center">
                   {/* Progress bar for auto-close */}
                   <motion.div
                     initial={{ width: "100%" }}


### PR DESCRIPTION
This pull request includes a minor change to the `ConfirmationModal` component. The padding of the modal's content was adjusted to use a specific pixel value for more precise styling.

Styling adjustment:

* [`client/src/components/ui/ConfirmationModal.tsx`](diffhunk://#diff-9bcf5c92a27bb1683a0b05818e0902b228a830d4cc0a326abc174bfd319749f6L76-R76): Changed the horizontal padding of the modal's content from `px-5` to `px-[22px]` for improved alignment and spacing.