### PR TITLE
refactor: Adjust padding in ConfirmationModal content for improved layout

### DIFF
--- a/client/src/components/ui/ConfirmationModal.tsx
+++ b/client/src/components/ui/ConfirmationModal.tsx
@@ -73,7 +73,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
                 </button>
                 
                 {/* Content */}
-                <div className="pt-7 pb-5 px-[22px] flex flex-col items-center">
+                <div className="pt-6 pb-5 px-[22px] flex flex-col items-center">
                   {/* Progress bar for auto-close */}
                   <motion.div
                     initial={{ width: "100%" }}


### PR DESCRIPTION
This pull request includes a minor adjustment to the `ConfirmationModal` component. The change modifies the padding-top (`pt-7` to `pt-6`) in the modal's content container to slightly reduce spacing for better alignment.