### PR TITLE
fix: Log publicId during media deletion and update Cloudinary test results timestamps and URLs

### DIFF
--- a/client/src/services/mediaService.ts
+++ b/client/src/services/mediaService.ts
@@ -107,6 +107,7 @@ export const deleteProjectMedia = async (
     // Make API request to delete from Cloudinary
     // The API expects the full Cloudinary publicId, not just the filename
     // and no need to include projectId in the URL since it's part of the publicId
+    console.log('Attempting to delete file with publicId:', mediaItem.publicId);
     await api.delete(`/uploads/projects/${encodeURIComponent(mediaItem.publicId)}`, config);
     
     return {

--- a/server/tools/cloudinary-test-results.json
+++ b/server/tools/cloudinary-test-results.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-08-05T08:16:48.846Z",
+  "timestamp": "2025-08-05T08:51:58.364Z",
   "summary": {
     "totalTests": 4,
     "passedTests": 4,
@@ -13,32 +13,32 @@
       "details": {
         "verified": true
       },
-      "timestamp": "2025-08-05T08:16:45.200Z"
+      "timestamp": "2025-08-05T08:51:52.608Z"
     },
     {
       "test": "Image upload",
       "success": true,
       "message": "Successfully uploaded test image to Cloudinary",
       "details": {
-        "publicId": "portfolio/projects/test-project-1754381805200/1754381805201",
-        "url": "https://res.cloudinary.com/dqzxpoez2/image/upload/v1754381806/portfolio/projects/test-project-1754381805200/1754381805201.png"
+        "publicId": "portfolio/projects/test-project-1754383912608/1754383912609",
+        "url": "https://res.cloudinary.com/dqzxpoez2/image/upload/v1754383916/portfolio/projects/test-project-1754383912608/1754383912609.png"
       },
-      "timestamp": "2025-08-05T08:16:48.246Z"
+      "timestamp": "2025-08-05T08:51:57.635Z"
     },
     {
       "test": "URL transformations",
       "success": true,
       "message": "Successfully generated transformed URLs",
       "details": {
-        "transformedUrl": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,h_100,q_auto,w_100/v1/portfolio/projects/test-project-1754381805200/1754381805201?_a=BAMAK+Xy0",
+        "transformedUrl": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,h_100,q_auto,w_100/v1/portfolio/projects/test-project-1754383912608/1754383912609?_a=BAMAK+Xy0",
         "responsiveUrls": {
-          "thumbnail": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_150,q_auto,w_150/v1/portfolio/projects/test-project-1754381805200/1754381805201?_a=BAMAK+Xy0",
-          "small": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_200,q_auto,w_300/v1/portfolio/projects/test-project-1754381805200/1754381805201?_a=BAMAK+Xy0",
-          "medium": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_400,q_auto,w_600/v1/portfolio/projects/test-project-1754381805200/1754381805201?_a=BAMAK+Xy0",
-          "large": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_800,q_auto,w_1200/v1/portfolio/projects/test-project-1754381805200/1754381805201?_a=BAMAK+Xy0"
+          "thumbnail": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_150,q_auto,w_150/v1/portfolio/projects/test-project-1754383912608/1754383912609?_a=BAMAK+Xy0",
+          "small": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_200,q_auto,w_300/v1/portfolio/projects/test-project-1754383912608/1754383912609?_a=BAMAK+Xy0",
+          "medium": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_400,q_auto,w_600/v1/portfolio/projects/test-project-1754383912608/1754383912609?_a=BAMAK+Xy0",
+          "large": "https://res.cloudinary.com/dqzxpoez2/image/upload/c_fill,f_auto,h_800,q_auto,w_1200/v1/portfolio/projects/test-project-1754383912608/1754383912609?_a=BAMAK+Xy0"
         }
       },
-      "timestamp": "2025-08-05T08:16:48.250Z"
+      "timestamp": "2025-08-05T08:51:57.638Z"
     },
     {
       "test": "File deletion",
@@ -47,7 +47,7 @@
       "details": {
         "result": "ok"
       },
-      "timestamp": "2025-08-05T08:16:48.843Z"
+      "timestamp": "2025-08-05T08:51:58.362Z"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces a minor debugging improvement to the media deletion service and updates the Cloudinary test results file with new timestamps and test asset references.

Debugging improvement:

* Added a `console.log` statement in `deleteProjectMedia` within `mediaService.ts` to log the `publicId` of the file being deleted, aiding in troubleshooting media deletion issues.

Test results update:

* Updated `cloudinary-test-results.json` with new timestamps and refreshed test asset references (public IDs and URLs) to reflect the latest test run outcomes. [[1]](diffhunk://#diff-4616453b9e31cfa039346edba8e9ffeba6db1f86d039bd1e46a1fae8eb395b41L2-R2) [[2]](diffhunk://#diff-4616453b9e31cfa039346edba8e9ffeba6db1f86d039bd1e46a1fae8eb395b41L16-R41) [[3]](diffhunk://#diff-4616453b9e31cfa039346edba8e9ffeba6db1f86d039bd1e46a1fae8eb395b41L50-R50)