### PR TITLE
fix: Remove streaming profile from video transformations and optimize upload options for better performance

### DIFF
--- a/client/src/utils/cloudinary.ts
+++ b/client/src/utils/cloudinary.ts
@@ -14,8 +14,8 @@ export const IMAGE_SIZES = {
 
 // Constants for video transformations
 export const VIDEO_TRANSFORMS = {
-  PREVIEW: { streaming_profile: 'hd', format: 'mp4', quality: 'auto:good' },
-  HD: { streaming_profile: 'hd', format: 'mp4', quality: 'auto:best' },
+  PREVIEW: { format: 'mp4', quality: 'auto:good' },
+  HD: { format: 'mp4', quality: 'auto:best' },
   THUMB: { width: 640, height: 360, crop: 'fill', format: 'jpg' }
 };
 

--- a/server/services/cloudinaryService.js
+++ b/server/services/cloudinaryService.js
@@ -65,7 +65,8 @@ class CloudinaryService {
       if (fileType === 'video') {
         // Enhanced video settings for better web delivery
         uploadOptions.eager = [
-          { streaming_profile: 'hd', format: 'mp4' }
+          // Use basic video optimization instead of streaming profile
+          { quality: 'auto', format: 'mp4' }
         ];
         uploadOptions.eager_async = true;
         // Add automatic audio normalization


### PR DESCRIPTION
This pull request updates how video files are processed and optimized in both the frontend and backend. The main focus is to remove the use of the deprecated or unnecessary `streaming_profile` option for Cloudinary video transformations and uploads, instead relying on quality-based optimizations.

**Video transformation and upload changes:**

* Removed the `streaming_profile: 'hd'` option from both `PREVIEW` and `HD` video transformation presets in `client/src/utils/cloudinary.ts`, now using only `format` and `quality` for video optimization.
* Updated the backend Cloudinary upload options in `server/services/cloudinaryService.js` to use `{ quality: 'auto', format: 'mp4' }` instead of `{ streaming_profile: 'hd', format: 'mp4' }` for eager video transformations.