### PR TITLE
feat: Implement media viewer functionality with toggle options and keyboard navigation

### DIFF
--- a/client/src/components/admin/projects/MediaUploader.tsx
+++ b/client/src/components/admin/projects/MediaUploader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Image, Video, X, UploadCloud, AlertCircle, ArrowLeft, ArrowRight, Eye } from 'lucide-react';
+import { Image, Video, X, UploadCloud, AlertCircle, ArrowLeft, ArrowRight, Eye, EyeOff } from 'lucide-react';
 import { ProjectMedia } from '../../../types';
 import { uploadProjectMedia, deleteProjectMedia } from '../../../services/mediaService';
 import { getTransformedImageUrl, getVideoThumbnail, isCloudinaryUrl } from '../../../utils/cloudinary';
@@ -212,6 +212,18 @@ const MediaUploader: React.FC<MediaUploaderProps> = ({
 
   // These functions were duplicates and have been merged with the ones above
 
+  // Toggle showInViewer property for a media item
+  const toggleShowInViewer = (index: number) => {
+    setMediaItems(prevItems => {
+      const newItems = [...prevItems];
+      newItems[index] = {
+        ...newItems[index],
+        showInViewer: !newItems[index].showInViewer
+      };
+      return newItems;
+    });
+  };
+
   // Preview a media item
   const [previewItem, setPreviewItem] = useState<ProjectMedia | null>(null);
   
@@ -345,6 +357,26 @@ const MediaUploader: React.FC<MediaUploaderProps> = ({
             {/* Order indicator */}
             <div className="absolute top-1 right-1 bg-black/70 text-white px-1.5 py-0.5 text-xs rounded-md z-20">
               {index + 1}/{mediaItems.length}
+            </div>
+            
+            {/* Show in viewer indicator */}
+            <div className="absolute bottom-1 left-1 z-20">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  toggleShowInViewer(index);
+                }}
+                className={`p-1 rounded text-xs transition-colors ${
+                  item.showInViewer !== false 
+                    ? 'bg-green-500 text-white hover:bg-green-600' 
+                    : 'bg-red-500 text-white hover:bg-red-600'
+                }`}
+                title={`${item.showInViewer !== false ? 'Hide from' : 'Show in'} popup viewer`}
+              >
+                {item.showInViewer !== false ? <Eye size={12} /> : <EyeOff size={12} />}
+              </button>
             </div>
             
             {/* Actions overlay */}
@@ -485,7 +517,10 @@ const MediaUploader: React.FC<MediaUploaderProps> = ({
         <p>Supported formats: </p>
         <p>• Images: JPG, PNG, GIF, WebP (max 5MB)</p>
         <p>• Videos: MP4, WebM, OGG (max 50MB)</p>
-        <p className="mt-1 italic">Tip: You can reorder media by using the arrow buttons that appear when hovering over an item.</p>
+        <p className="mt-1 italic">Tips:</p>
+        <p className="italic">• Reorder media using arrow buttons on hover</p>
+        <p className="italic">• Toggle eye icon to show/hide in client popup viewer</p>
+        <p className="italic">• Green eye = shows in popup viewer, Red eye = hidden from popup</p>
       </div>
       
       {/* Media preview modal - render outside form context using portal */}

--- a/client/src/components/ui/MediaViewer.tsx
+++ b/client/src/components/ui/MediaViewer.tsx
@@ -1,0 +1,319 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { 
+  X, 
+  ChevronLeft, 
+  ChevronRight, 
+  Play, 
+  Pause, 
+  Maximize2,
+  Volume2,
+  VolumeX
+} from 'lucide-react';
+import { ProjectMedia } from '../../types';
+import { getTransformedImageUrl, isCloudinaryUrl } from '../../utils/cloudinary';
+
+interface MediaViewerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mediaItems: ProjectMedia[];
+  projectTitle: string;
+  initialIndex?: number;
+}
+
+const MediaViewer: React.FC<MediaViewerProps> = ({
+  isOpen,
+  onClose,
+  mediaItems,
+  projectTitle,
+  initialIndex = 0
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isMuted, setIsMuted] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Filter media items to only show those marked for viewer
+  const viewerMediaItems = mediaItems.filter(item => item.showInViewer !== false);
+
+  // Reset index when media items change
+  useEffect(() => {
+    setCurrentIndex(Math.min(initialIndex, viewerMediaItems.length - 1));
+  }, [viewerMediaItems, initialIndex]);
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Escape':
+          onClose();
+          break;
+        case 'ArrowLeft':
+          navigatePrev();
+          break;
+        case 'ArrowRight':
+          navigateNext();
+          break;
+        case ' ':
+          e.preventDefault();
+          if (currentItem?.type === 'video') {
+            togglePlayPause();
+          }
+          break;
+        case 'f':
+        case 'F':
+          if (currentItem?.type === 'video') {
+            toggleFullscreen();
+          }
+          break;
+        case 'm':
+        case 'M':
+          if (currentItem?.type === 'video') {
+            toggleMute();
+          }
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, currentIndex, viewerMediaItems]);
+
+  // Handle fullscreen events
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  // Disable scroll on body when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  if (!isOpen || viewerMediaItems.length === 0) return null;
+
+  const currentItem = viewerMediaItems[currentIndex];
+
+  const navigatePrev = () => {
+    setCurrentIndex(prev => 
+      prev === 0 ? viewerMediaItems.length - 1 : prev - 1
+    );
+  };
+
+  const navigateNext = () => {
+    setCurrentIndex(prev => 
+      (prev + 1) % viewerMediaItems.length
+    );
+  };
+
+  const togglePlayPause = () => {
+    if (!videoRef.current) return;
+    
+    if (isPlaying) {
+      videoRef.current.pause();
+    } else {
+      videoRef.current.play();
+    }
+    setIsPlaying(!isPlaying);
+  };
+
+  const toggleMute = () => {
+    if (!videoRef.current) return;
+    
+    videoRef.current.muted = !videoRef.current.muted;
+    setIsMuted(videoRef.current.muted);
+  };
+
+  const toggleFullscreen = async () => {
+    if (!containerRef.current) return;
+
+    try {
+      if (!document.fullscreenElement) {
+        await containerRef.current.requestFullscreen();
+      } else {
+        await document.exitFullscreen();
+      }
+    } catch (error) {
+      console.error('Fullscreen error:', error);
+    }
+  };
+
+  const handleVideoLoadedData = () => {
+    if (videoRef.current) {
+      videoRef.current.muted = isMuted;
+    }
+  };
+
+  return createPortal(
+    <div 
+      ref={containerRef}
+      className={`fixed inset-0 bg-black z-50 flex items-center justify-center ${
+        isFullscreen ? 'bg-black' : 'bg-black/95'
+      }`}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      {/* Header */}
+      <div className="absolute top-0 left-0 right-0 z-50 bg-gradient-to-b from-black/80 to-transparent p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-white text-lg font-semibold truncate">
+            {projectTitle} - Media Viewer
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 text-white hover:text-red-400 transition-colors"
+            aria-label="Close media viewer"
+          >
+            <X size={24} />
+          </button>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="relative w-full h-full flex items-center justify-center p-16">
+        {/* Current Media */}
+        <div className="relative max-w-full max-h-full">
+          {currentItem.type === 'image' ? (
+            <img
+              src={isCloudinaryUrl(currentItem.url) 
+                ? getTransformedImageUrl(currentItem.url, { width: 1920, height: 1080, quality: 'auto' })
+                : currentItem.url
+              }
+              alt={`${projectTitle} media ${currentIndex + 1}`}
+              className="max-w-full max-h-full object-contain"
+              style={{ maxHeight: 'calc(100vh - 8rem)' }}
+              onContextMenu={(e) => e.preventDefault()} // Disable right-click download
+              draggable={false} // Disable drag download
+            />
+          ) : (
+            <video
+              ref={videoRef}
+              src={currentItem.url}
+              className="max-w-full max-h-full object-contain"
+              style={{ maxHeight: 'calc(100vh - 8rem)' }}
+              onLoadedData={handleVideoLoadedData}
+              onPlay={() => setIsPlaying(true)}
+              onPause={() => setIsPlaying(false)}
+              onContextMenu={(e) => e.preventDefault()} // Disable right-click download
+              loop
+              playsInline
+              controlsList="nodownload" // Disable download option in controls
+            />
+          )}
+        </div>
+
+        {/* Navigation Controls */}
+        {viewerMediaItems.length > 1 && (
+          <>
+            <button
+              onClick={navigatePrev}
+              className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all"
+              aria-label="Previous media"
+            >
+              <ChevronLeft size={24} />
+            </button>
+            
+            <button
+              onClick={navigateNext}
+              className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all"
+              aria-label="Next media"
+            >
+              <ChevronRight size={24} />
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Bottom Controls */}
+      <div className="absolute bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-black/80 to-transparent p-4">
+        <div className="flex items-center justify-between">
+          {/* Media Counter */}
+          <div className="text-white text-sm">
+            {currentIndex + 1} of {viewerMediaItems.length}
+          </div>
+
+          {/* Video Controls */}
+          {currentItem.type === 'video' && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={togglePlayPause}
+                className="p-2 bg-white/20 text-white rounded-full hover:bg-white/30 transition-colors"
+                aria-label={isPlaying ? 'Pause' : 'Play'}
+              >
+                {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+              </button>
+              
+              <button
+                onClick={toggleMute}
+                className="p-2 bg-white/20 text-white rounded-full hover:bg-white/30 transition-colors"
+                aria-label={isMuted ? 'Unmute' : 'Mute'}
+              >
+                {isMuted ? <VolumeX size={20} /> : <Volume2 size={20} />}
+              </button>
+              
+              <button
+                onClick={toggleFullscreen}
+                className="p-2 bg-white/20 text-white rounded-full hover:bg-white/30 transition-colors"
+                aria-label="Toggle fullscreen"
+              >
+                <Maximize2 size={20} />
+              </button>
+            </div>
+          )}
+
+          {/* Dots Indicator */}
+          {viewerMediaItems.length > 1 && (
+            <div className="flex items-center gap-2">
+              {viewerMediaItems.map((_, index) => (
+                <button
+                  key={index}
+                  onClick={() => setCurrentIndex(index)}
+                  className={`w-3 h-3 rounded-full transition-all ${
+                    index === currentIndex 
+                      ? 'bg-white' 
+                      : 'bg-white/40 hover:bg-white/60'
+                  }`}
+                  aria-label={`Go to media ${index + 1}`}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Keyboard shortcuts help */}
+      <div className="absolute top-16 right-4 text-white/70 text-xs max-w-xs">
+        <div className="bg-black/60 rounded-lg p-3 backdrop-blur-sm">
+          <div className="font-semibold mb-2">Keyboard Shortcuts</div>
+          <div>← → Navigate</div>
+          <div>Space: Play/Pause</div>
+          <div>F: Fullscreen</div>
+          <div>M: Mute/Unmute</div>
+          <div>Esc: Close</div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default MediaViewer;

--- a/client/src/components/ui/MediaViewerPopup.tsx
+++ b/client/src/components/ui/MediaViewerPopup.tsx
@@ -1,0 +1,316 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { ProjectMedia } from '../../types';
+import { 
+  ChevronLeft, 
+  ChevronRight, 
+  Play, 
+  Pause, 
+  X, 
+  Maximize, 
+  Minimize, 
+  Eye
+} from 'lucide-react';
+import { getTransformedImageUrl, isCloudinaryUrl } from '../../utils/cloudinary';
+
+interface MediaViewerPopupProps {
+  mediaItems: ProjectMedia[];
+  isOpen: boolean;
+  onClose: () => void;
+  projectTitle: string;
+  autoplay?: boolean;
+  interval?: number; // in milliseconds
+}
+
+const MediaViewerPopup: React.FC<MediaViewerPopupProps> = ({ 
+  mediaItems, 
+  isOpen,
+  onClose,
+  projectTitle,
+  autoplay = true,
+  interval = 4000 
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(autoplay);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const autoplayTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Filter media items to only show those marked for popup display
+  const popupMediaItems = mediaItems.filter(item => item.showInViewer !== false);
+
+  // Find the displayFirst item and use its index among popup items
+  useEffect(() => {
+    if (popupMediaItems.length > 0) {
+      const displayFirstIndex = popupMediaItems.findIndex(item => item.displayFirst);
+      if (displayFirstIndex !== -1) {
+        setCurrentIndex(displayFirstIndex);
+      } else {
+        setCurrentIndex(0);
+      }
+    }
+  }, [popupMediaItems]);
+
+  // Handle autoplay
+  useEffect(() => {
+    // Clear any existing autoplay timer
+    if (autoplayTimerRef.current) {
+      clearTimeout(autoplayTimerRef.current);
+      autoplayTimerRef.current = null;
+    }
+
+    // Only setup autoplay if there's more than one media item, autoplay is enabled, and popup is open
+    if (popupMediaItems.length > 1 && isPlaying && isOpen) {
+      autoplayTimerRef.current = setTimeout(() => {
+        setCurrentIndex(prevIndex => (prevIndex + 1) % popupMediaItems.length);
+      }, interval);
+    }
+
+    // Cleanup timer on unmount
+    return () => {
+      if (autoplayTimerRef.current) {
+        clearTimeout(autoplayTimerRef.current);
+      }
+    };
+  }, [currentIndex, popupMediaItems, isPlaying, interval, isOpen]);
+
+  // Handle video element when type changes or current index changes
+  useEffect(() => {
+    const currentItem = popupMediaItems[currentIndex];
+    if (currentItem?.type === 'video' && videoRef.current) {
+      // Reset video to beginning
+      videoRef.current.currentTime = 0;
+      
+      // Play the current video if autoplay is enabled
+      if (isPlaying && isOpen) {
+        videoRef.current.play().catch(err => {
+          console.error('Video play error:', err);
+        });
+      } else {
+        videoRef.current.pause();
+      }
+    }
+  }, [currentIndex, isPlaying, popupMediaItems, isOpen]);
+
+  // Handle escape key to close popup
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (isFullscreen) {
+          exitFullscreen();
+        } else {
+          onClose();
+        }
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      // Prevent body scroll when popup is open
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, isFullscreen, onClose]);
+
+  // Fullscreen functionality
+  const enterFullscreen = () => {
+    if (containerRef.current) {
+      if (containerRef.current.requestFullscreen) {
+        containerRef.current.requestFullscreen();
+      }
+      setIsFullscreen(true);
+    }
+  };
+
+  const exitFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+    setIsFullscreen(false);
+  };
+
+  // Handle fullscreen change events
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  // Don't render if not open or no media items to show
+  if (!isOpen || popupMediaItems.length === 0) {
+    return null;
+  }
+
+  const currentItem = popupMediaItems[currentIndex];
+
+  const navigatePrev = () => {
+    setCurrentIndex(prevIndex => {
+      if (prevIndex === 0) return popupMediaItems.length - 1;
+      return prevIndex - 1;
+    });
+  };
+
+  const navigateNext = () => {
+    setCurrentIndex(prevIndex => (prevIndex + 1) % popupMediaItems.length);
+  };
+
+  const togglePlayPause = () => {
+    setIsPlaying(!isPlaying);
+  };
+
+  // Prevent download by disabling right-click and drag
+  const preventDownload = (e: React.MouseEvent | React.DragEvent) => {
+    e.preventDefault();
+    return false;
+  };
+
+  const popup = (
+    <div 
+      ref={containerRef}
+      className={`fixed inset-0 bg-black/95 backdrop-blur-sm flex items-center justify-center z-[9999] ${
+        isFullscreen ? 'bg-black' : ''
+      }`}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      {/* Header */}
+      <div className={`absolute top-0 left-0 right-0 z-50 p-4 bg-gradient-to-b from-black/80 to-transparent ${
+        isFullscreen ? 'opacity-0 hover:opacity-100 transition-opacity' : ''
+      }`}>
+        <div className="flex items-center justify-between text-white">
+          <div className="flex items-center gap-3">
+            <Eye size={20} />
+            <h3 className="text-lg font-semibold">{projectTitle}</h3>
+            <span className="text-sm text-white/70">
+              {currentIndex + 1} of {popupMediaItems.length}
+            </span>
+          </div>
+          
+          <div className="flex items-center gap-2">
+            {/* Fullscreen toggle */}
+            <button
+              onClick={isFullscreen ? exitFullscreen : enterFullscreen}
+              className="p-2 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all focus:outline-none"
+              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            >
+              {isFullscreen ? <Minimize size={18} /> : <Maximize size={18} />}
+            </button>
+            
+            {/* Close button */}
+            <button
+              onClick={onClose}
+              className="p-2 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all focus:outline-none"
+              aria-label="Close viewer"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Main content area */}
+      <div className="relative w-full h-full flex items-center justify-center p-4 pt-20 pb-20">
+        {/* Current media item */}
+        <div className="relative max-w-7xl max-h-full flex items-center justify-center">
+          {currentItem?.type === 'image' ? (
+            <img 
+              src={isCloudinaryUrl(currentItem.url) 
+                ? getTransformedImageUrl(currentItem.url, { 
+                    width: isFullscreen ? 1920 : 1200, 
+                    height: isFullscreen ? 1080 : 800, 
+                    quality: 'auto' 
+                  }) 
+                : currentItem.url
+              }
+              alt={`${projectTitle} - Media ${currentIndex + 1}`}
+              className="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
+              onContextMenu={preventDownload}
+              onDragStart={preventDownload}
+              style={{ userSelect: 'none' }}
+            />
+          ) : currentItem?.type === 'video' ? (
+            <video 
+              ref={videoRef}
+              src={currentItem.url}
+              controls={true}
+              controlsList="nodownload"
+              disablePictureInPicture
+              onContextMenu={preventDownload}
+              className="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
+              style={{ userSelect: 'none' }}
+            />
+          ) : null}
+        </div>
+
+        {/* Navigation arrows (only show if multiple items) */}
+        {popupMediaItems.length > 1 && (
+          <>
+            <button 
+              onClick={navigatePrev}
+              className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all focus:outline-none shadow-lg hover:scale-110 z-40"
+              aria-label="Previous media"
+            >
+              <ChevronLeft size={24} />
+            </button>
+            <button 
+              onClick={navigateNext}
+              className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all focus:outline-none shadow-lg hover:scale-110 z-40"
+              aria-label="Next media"
+            >
+              <ChevronRight size={24} />
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Bottom controls */}
+      <div className={`absolute bottom-0 left-0 right-0 z-50 p-4 bg-gradient-to-t from-black/80 to-transparent ${
+        isFullscreen ? 'opacity-0 hover:opacity-100 transition-opacity' : ''
+      }`}>
+        <div className="flex items-center justify-between">
+          {/* Media indicator dots */}
+          <div className="flex gap-2">
+            {popupMediaItems.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => setCurrentIndex(index)}
+                className={`w-3 h-3 rounded-full transition-all focus:outline-none hover:scale-125 ${
+                  index === currentIndex 
+                    ? 'bg-primary shadow-lg scale-110' 
+                    : 'bg-white/60 hover:bg-white/80'
+                }`}
+                aria-label={`Go to media ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          {/* Play/Pause button (only show if multiple items) */}
+          {popupMediaItems.length > 1 && (
+            <button 
+              onClick={togglePlayPause}
+              className="p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all focus:outline-none shadow-lg hover:scale-110"
+              aria-label={isPlaying ? "Pause slideshow" : "Start slideshow"}
+            >
+              {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(popup, document.body);
+};
+
+export default MediaViewerPopup;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -29,6 +29,7 @@ export interface ProjectMedia {
   isExternal: boolean;
   order: number;
   displayFirst: boolean;
+  showInViewer?: boolean; // Controls whether this media appears in client-side popup viewer
   _id?: string; // MongoDB will generate this
 }
 

--- a/server/routes/uploads.js
+++ b/server/routes/uploads.js
@@ -63,7 +63,8 @@ router.post('/projects/:projectId', protect, upload.fields([
           publicId: result.public_id, // Store Cloudinary public_id for later manipulation
           isExternal: false,
           order: index,
-          displayFirst: index === 0 && !files.video // First image is display first only if no videos
+          displayFirst: index === 0 && !files.video, // First image is display first only if no videos
+          showInViewer: true // Default to showing in viewer, admin can change this
         };
       });
       
@@ -82,7 +83,8 @@ router.post('/projects/:projectId', protect, upload.fields([
           publicId: result.public_id, // Store Cloudinary public_id for later manipulation
           isExternal: false,
           order: files.image ? files.image.length + index : index,
-          displayFirst: index === 0 // First video is display first by default
+          displayFirst: index === 0, // First video is display first by default
+          showInViewer: true // Default to showing in viewer, admin can change this
         };
       });
       


### PR DESCRIPTION
This pull request introduces a new feature that allows admins to control which project media items are visible in the client popup viewer. It also updates the project section and media carousel to support this feature, providing a more customizable and user-friendly media viewing experience for both admins and end users.

**Admin Media Visibility Controls:**
- Adds a toggle button (eye icon) in the admin media uploader (`MediaUploader.tsx`) to set whether each media item should appear in the client popup viewer. The UI provides clear indicators and tips for this functionality. [[1]](diffhunk://#diff-8efc2b7753d6d67c70487dc7a9745a2601326d789c6205ab75787343444528aeL3-R3) [[2]](diffhunk://#diff-8efc2b7753d6d67c70487dc7a9745a2601326d789c6205ab75787343444528aeR215-R226) [[3]](diffhunk://#diff-8efc2b7753d6d67c70487dc7a9745a2601326d789c6205ab75787343444528aeR362-R381) [[4]](diffhunk://#diff-8efc2b7753d6d67c70487dc7a9745a2601326d789c6205ab75787343444528aeL488-R523)

**Client Project Section & Media Viewer Integration:**
- Updates the project section to filter media items based on the new `showInViewer` property, ensuring only selected media are shown in the carousel and popup viewer. Adds logic to open a dedicated media viewer modal for projects. [[1]](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R6) [[2]](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R21-R25) [[3]](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R72-R93) [[4]](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573L154-R188) [[5]](diffhunk://#diff-9917a588712ba5bf57782ba63e8c53bf29aedcd46b97b52137778025ee69d573R280-R289)

**Media Carousel Enhancements:**
- Adds a "View Media" button (eye icon) to the carousel, allowing users to open the media viewer popup. Improves accessibility and styling of carousel controls, and ensures only media marked for viewing are displayed. [[1]](diffhunk://#diff-43725adb43c00b9b4eaad0c62aa0800700548b225194c7e905c5fa1336ad2454L3-R3) [[2]](diffhunk://#diff-43725adb43c00b9b4eaad0c62aa0800700548b225194c7e905c5fa1336ad2454R12-R13) [[3]](diffhunk://#diff-43725adb43c00b9b4eaad0c62aa0800700548b225194c7e905c5fa1336ad2454L20-R24) [[4]](diffhunk://#diff-43725adb43c00b9b4eaad0c62aa0800700548b225194c7e905c5fa1336ad2454L122-R200)