### PR TITLE
feat: Add showInViewer property to media schema and enhance logging in MediaUploader and MediaViewer

### DIFF
--- a/client/src/components/admin/projects/MediaUploader.tsx
+++ b/client/src/components/admin/projects/MediaUploader.tsx
@@ -216,12 +216,27 @@ const MediaUploader: React.FC<MediaUploaderProps> = ({
   const toggleShowInViewer = (index: number) => {
     setMediaItems(prevItems => {
       const newItems = [...prevItems];
-      const newValue = !newItems[index].showInViewer;
-      console.log(`Setting showInViewer for item ${index} to ${newValue}`);
+      
+      // Check current value
+      const currentValue = newItems[index].showInViewer;
+      // Calculate new value - ensuring it's explicitly true or false, not undefined
+      const newValue = currentValue === false ? true : false;
+      
+      console.log(`Setting showInViewer for item ${index} from ${currentValue} to ${newValue}`);
+      
+      // Create a new object to ensure React detects the change
       newItems[index] = {
         ...newItems[index],
         showInViewer: newValue
       };
+      
+      // Log all media items after update
+      console.log('Updated media items:', newItems.map((item, i) => ({ 
+        index: i,
+        url: item.url.substring(0, 20) + '...',
+        showInViewer: item.showInViewer
+      })));
+      
       return newItems;
     });
   };

--- a/client/src/components/admin/projects/ProjectsAdmin.tsx
+++ b/client/src/components/admin/projects/ProjectsAdmin.tsx
@@ -288,6 +288,13 @@ function ProjectsAdmin({ token }: ProjectsAdminProps): JSX.Element {
           toast.error(`Failed to update project: ${response.error}`);
         } else {
           // Update projects list, ensuring we match by the correct ID
+          console.log('Project update response data:', response.data);
+          console.log('Media items in response:', response.data.media);
+          console.log('showInViewer values in response:', response.data.media?.map(item => ({
+            url: item.url.substring(0, 20) + '...',
+            showInViewer: item.showInViewer
+          })));
+          
           setProjects(prev =>
             prev.map(project => {
               const itemId = project.id || (project as any)._id;

--- a/client/src/components/ui/MediaViewer.tsx
+++ b/client/src/components/ui/MediaViewer.tsx
@@ -38,7 +38,17 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Filter media items to only show those marked for viewer
-  const viewerMediaItems = mediaItems.filter(item => item.showInViewer !== false);
+  console.log('MediaViewer received items:', mediaItems);
+  console.log('MediaItems showInViewer values:', mediaItems.map(item => ({ 
+    url: item.url.substring(0, 30) + '...', 
+    showInViewer: item.showInViewer 
+  })));
+  
+  const viewerMediaItems = mediaItems.filter(item => {
+    const shouldShow = item.showInViewer !== false;
+    console.log(`Item ${item.url.substring(0, 30)}... showInViewer=${item.showInViewer}, shouldShow=${shouldShow}`);
+    return shouldShow;
+  });
 
   // Reset index when media items change
   useEffect(() => {
@@ -260,11 +270,13 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
               <button
                 onClick={(e) => {
                   e.preventDefault();
-                  navigatePrev(e);
-                  console.log('Previous clicked, navigating to index:', 
-                    currentIndex === 0 ? viewerMediaItems.length - 1 : currentIndex - 1);
+                  e.stopPropagation();
+                  console.log('Previous button clicked');
+                  const newIndex = currentIndex === 0 ? viewerMediaItems.length - 1 : currentIndex - 1;
+                  console.log(`Navigating from ${currentIndex} to ${newIndex}`);
+                  setCurrentIndex(newIndex);
                 }}
-                className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-20 cursor-pointer"
+                className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-[9999] cursor-pointer"
                 aria-label="Previous media"
               >
                 <ChevronLeft size={24} />
@@ -273,11 +285,13 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
               <button
                 onClick={(e) => {
                   e.preventDefault();
-                  navigateNext(e);
-                  console.log('Next clicked, navigating to index:', 
-                    (currentIndex + 1) % viewerMediaItems.length);
+                  e.stopPropagation();
+                  console.log('Next button clicked');
+                  const newIndex = (currentIndex + 1) % viewerMediaItems.length;
+                  console.log(`Navigating from ${currentIndex} to ${newIndex}`);
+                  setCurrentIndex(newIndex);
                 }}
-                className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-20 cursor-pointer"
+                className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-[9999] cursor-pointer"
                 aria-label="Next media"
               >
                 <ChevronRight size={24} />

--- a/server/models/Project.js
+++ b/server/models/Project.js
@@ -26,6 +26,10 @@ const mediaSchema = new mongoose.Schema({
   displayFirst: {
     type: Boolean,
     default: false
+  },
+  showInViewer: {
+    type: Boolean,
+    default: true
   }
 });
 


### PR DESCRIPTION
This pull request adds and improves support for the `showInViewer` property on media items in projects, making it possible to control which media items appear in the viewer component. It also introduces extensive logging to help debug and verify the correct behavior of this property throughout the admin and UI components. Additionally, some UI improvements were made to the media navigation buttons.

**Media item property and backend schema:**

* Added a `showInViewer` boolean property with a default of `true` to the `media` schema in `server/models/Project.js`, allowing media items to be toggled for visibility in the viewer.

**Debugging and logging enhancements:**

* Added detailed logging in `MediaUploader.tsx` to track changes to the `showInViewer` property and to log the state of all media items after updates.
* Added logging in `ProjectsAdmin.tsx` to inspect the updated project data, especially the `showInViewer` values of media items after a project update.
* Added logging in `MediaViewer.tsx` to display received media items and their `showInViewer` values, and to log filtering decisions for which items are shown in the viewer.

**Media viewer navigation improvements:**

* Updated previous and next navigation button handlers in `MediaViewer.tsx` to use local state updates, stop event propagation, and provide more detailed navigation logs. Also increased their z-index for better UI layering. [[1]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL263-R279) [[2]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL276-R294)