### PR TITLE
feat: Refactor navigation and playback functions in MediaViewer and MediaViewerPopup for improved code organization

### DIFF
--- a/client/src/components/ui/MediaViewer.tsx
+++ b/client/src/components/ui/MediaViewer.tsx
@@ -55,6 +55,58 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
     setCurrentIndex(Math.min(initialIndex, viewerMediaItems.length - 1));
   }, [viewerMediaItems, initialIndex]);
 
+  // Define navigation functions early to be used in useEffect hooks
+  const navigatePrev = (e?: React.MouseEvent) => {
+    if (e) e.stopPropagation(); // Prevent event bubbling
+    setCurrentIndex(prev => 
+      prev === 0 ? viewerMediaItems.length - 1 : prev - 1
+    );
+  };
+
+  const navigateNext = (e?: React.MouseEvent) => {
+    if (e) e.stopPropagation(); // Prevent event bubbling
+    setCurrentIndex(prev => 
+      (prev + 1) % viewerMediaItems.length
+    );
+  };
+
+  const togglePlayPause = () => {
+    if (!videoRef.current) return;
+    
+    if (isPlaying) {
+      videoRef.current.pause();
+    } else {
+      videoRef.current.play().catch(err => {
+        console.error('Error playing video:', err);
+      });
+    }
+    setIsPlaying(!isPlaying);
+  };
+
+  const toggleMute = () => {
+    if (!videoRef.current) return;
+    
+    videoRef.current.muted = !videoRef.current.muted;
+    setIsMuted(videoRef.current.muted);
+  };
+
+  const toggleFullscreen = async (e?: React.MouseEvent) => {
+    if (e) e.stopPropagation(); // Prevent event bubbling
+    if (!containerRef.current) return;
+
+    try {
+      if (!document.fullscreenElement) {
+        await containerRef.current.requestFullscreen();
+        setIsFullscreen(true);
+      } else {
+        await document.exitFullscreen();
+        setIsFullscreen(false);
+      }
+    } catch (error) {
+      console.error('Fullscreen error:', error);
+    }
+  };
+
   // Handle keyboard navigation
   useEffect(() => {
     if (!isOpen) return;
@@ -133,57 +185,6 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
   if (!isOpen || viewerMediaItems.length === 0) return null;
 
   const currentItem = viewerMediaItems[currentIndex];
-
-  const navigatePrev = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation(); // Prevent event bubbling
-    setCurrentIndex(prev => 
-      prev === 0 ? viewerMediaItems.length - 1 : prev - 1
-    );
-  };
-
-  const navigateNext = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation(); // Prevent event bubbling
-    setCurrentIndex(prev => 
-      (prev + 1) % viewerMediaItems.length
-    );
-  };
-
-  const togglePlayPause = () => {
-    if (!videoRef.current) return;
-    
-    if (isPlaying) {
-      videoRef.current.pause();
-    } else {
-      videoRef.current.play().catch(err => {
-        console.error('Error playing video:', err);
-      });
-    }
-    setIsPlaying(!isPlaying);
-  };
-
-  const toggleMute = () => {
-    if (!videoRef.current) return;
-    
-    videoRef.current.muted = !videoRef.current.muted;
-    setIsMuted(videoRef.current.muted);
-  };
-
-  const toggleFullscreen = async (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation(); // Prevent event bubbling
-    if (!containerRef.current) return;
-
-    try {
-      if (!document.fullscreenElement) {
-        await containerRef.current.requestFullscreen();
-        setIsFullscreen(true);
-      } else {
-        await document.exitFullscreen();
-        setIsFullscreen(false);
-      }
-    } catch (error) {
-      console.error('Fullscreen error:', error);
-    }
-  };
 
   const handleVideoLoadedData = () => {
     if (videoRef.current) {
@@ -272,9 +273,7 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
                   e.preventDefault();
                   e.stopPropagation();
                   console.log('Previous button clicked');
-                  const newIndex = currentIndex === 0 ? viewerMediaItems.length - 1 : currentIndex - 1;
-                  console.log(`Navigating from ${currentIndex} to ${newIndex}`);
-                  setCurrentIndex(newIndex);
+                  navigatePrev(e);
                 }}
                 className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-[9999] cursor-pointer"
                 aria-label="Previous media"
@@ -287,9 +286,7 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
                   e.preventDefault();
                   e.stopPropagation();
                   console.log('Next button clicked');
-                  const newIndex = (currentIndex + 1) % viewerMediaItems.length;
-                  console.log(`Navigating from ${currentIndex} to ${newIndex}`);
-                  setCurrentIndex(newIndex);
+                  navigateNext(e);
                 }}
                 className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black/60 text-white rounded-full hover:bg-black/80 transition-all z-[9999] cursor-pointer"
                 aria-label="Next media"

--- a/client/src/components/ui/MediaViewerPopup.tsx
+++ b/client/src/components/ui/MediaViewerPopup.tsx
@@ -40,6 +40,22 @@ const MediaViewerPopup: React.FC<MediaViewerPopupProps> = ({
   // Filter media items to only show those marked for popup display
   const popupMediaItems = mediaItems.filter(item => item.showInViewer !== false);
 
+  // Navigation functions defined early to be used in useEffect hooks
+  const navigatePrev = () => {
+    setCurrentIndex(prevIndex => {
+      if (prevIndex === 0) return popupMediaItems.length - 1;
+      return prevIndex - 1;
+    });
+  };
+
+  const navigateNext = () => {
+    setCurrentIndex(prevIndex => (prevIndex + 1) % popupMediaItems.length);
+  };
+
+  const togglePlayPause = () => {
+    setIsPlaying(!isPlaying);
+  };
+
   // Find the displayFirst item and use its index among popup items
   useEffect(() => {
     if (popupMediaItems.length > 0) {
@@ -185,21 +201,6 @@ const MediaViewerPopup: React.FC<MediaViewerPopupProps> = ({
   }
 
   const currentItem = popupMediaItems[currentIndex];
-
-  const navigatePrev = () => {
-    setCurrentIndex(prevIndex => {
-      if (prevIndex === 0) return popupMediaItems.length - 1;
-      return prevIndex - 1;
-    });
-  };
-
-  const navigateNext = () => {
-    setCurrentIndex(prevIndex => (prevIndex + 1) % popupMediaItems.length);
-  };
-
-  const togglePlayPause = () => {
-    setIsPlaying(!isPlaying);
-  };
 
   // Prevent download by disabling right-click and drag
   const preventDownload = (e: React.MouseEvent | React.DragEvent) => {


### PR DESCRIPTION
This pull request refactors the navigation and media control logic in both the `MediaViewer` and `MediaViewerPopup` components to improve code organization and maintainability. The main changes involve moving the navigation and control functions to be defined earlier in the component, making them available for use in `useEffect` hooks and other handlers, and simplifying the event handling in navigation buttons.

**Refactoring and Code Organization:**

* Moved the navigation (`navigatePrev`, `navigateNext`) and media control (`togglePlayPause`, `toggleMute`, `toggleFullscreen`) functions to be defined earlier in the `MediaViewer` component, before their first usage, allowing them to be used in `useEffect` hooks and improving code clarity.
* Removed the previous definitions of these functions from later in the `MediaViewer` component to prevent duplication and maintain a single source of truth.
* Updated the navigation button handlers in `MediaViewer` to use the new `navigatePrev` and `navigateNext` functions, simplifying the event handling logic and reducing code repetition. [[1]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL275-R276) [[2]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL290-R289)
* Applied the same refactoring approach to the `MediaViewerPopup` component by moving the navigation and play/pause functions to the top for better accessibility throughout the component. [[1]](diffhunk://#diff-d689eb692e2884524c9249e61b38807c097db678a73897752b68a0be13d308deR43-R58) [[2]](diffhunk://#diff-d689eb692e2884524c9249e61b38807c097db678a73897752b68a0be13d308deL189-L203)