### PR TITLE
feat: Refactor navigation and fullscreen functions in MediaViewer and MediaViewerPopup to use useCallback for improved performance

### DIFF
--- a/client/src/components/ui/MediaViewer.tsx
+++ b/client/src/components/ui/MediaViewer.tsx
@@ -55,22 +55,28 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
     setCurrentIndex(Math.min(initialIndex, viewerMediaItems.length - 1));
   }, [viewerMediaItems, initialIndex]);
 
-  // Define navigation functions early to be used in useEffect hooks
-  const navigatePrev = (e?: React.MouseEvent) => {
+  // Define navigation functions as useCallback hooks to ensure stability between renders
+  const navigatePrev = React.useCallback((e?: React.MouseEvent) => {
     if (e) e.stopPropagation(); // Prevent event bubbling
     setCurrentIndex(prev => 
       prev === 0 ? viewerMediaItems.length - 1 : prev - 1
     );
-  };
+  }, [viewerMediaItems.length]);
 
-  const navigateNext = (e?: React.MouseEvent) => {
+  const navigateNext = React.useCallback((e?: React.MouseEvent) => {
     if (e) e.stopPropagation(); // Prevent event bubbling
     setCurrentIndex(prev => 
       (prev + 1) % viewerMediaItems.length
     );
-  };
+  }, [viewerMediaItems.length]);
+  
+  const goToIndex = React.useCallback((index: number, e?: React.MouseEvent) => {
+    if (e) e.stopPropagation(); // Prevent event bubbling
+    console.log(`Going to index: ${index}`);
+    setCurrentIndex(index);
+  }, []);
 
-  const togglePlayPause = () => {
+  const togglePlayPause = React.useCallback(() => {
     if (!videoRef.current) return;
     
     if (isPlaying) {
@@ -81,16 +87,16 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
       });
     }
     setIsPlaying(!isPlaying);
-  };
+  }, [isPlaying]);
 
-  const toggleMute = () => {
+  const toggleMute = React.useCallback(() => {
     if (!videoRef.current) return;
     
     videoRef.current.muted = !videoRef.current.muted;
     setIsMuted(videoRef.current.muted);
-  };
+  }, []);
 
-  const toggleFullscreen = async (e?: React.MouseEvent) => {
+  const toggleFullscreen = React.useCallback(async (e?: React.MouseEvent) => {
     if (e) e.stopPropagation(); // Prevent event bubbling
     if (!containerRef.current) return;
 
@@ -105,7 +111,7 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
     } catch (error) {
       console.error('Fullscreen error:', error);
     }
-  };
+  }, []);
 
   // Handle keyboard navigation
   useEffect(() => {
@@ -157,7 +163,7 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, currentIndex, isFullscreen]);
+  }, [isOpen, currentIndex, isFullscreen, navigatePrev, navigateNext, togglePlayPause, toggleMute, toggleFullscreen, onClose, viewerMediaItems]);
 
   // Handle fullscreen events
   useEffect(() => {
@@ -354,7 +360,7 @@ const MediaViewer: React.FC<MediaViewerProps> = ({
                       e.preventDefault();
                       e.stopPropagation(); // Prevent modal close
                       console.log('Indicator dot clicked, navigating to index:', index);
-                      setCurrentIndex(index);
+                      goToIndex(index, e);
                     }}
                     className={`w-3 h-3 rounded-full transition-all cursor-pointer ${
                       index === currentIndex 

--- a/client/src/components/ui/MediaViewerPopup.tsx
+++ b/client/src/components/ui/MediaViewerPopup.tsx
@@ -40,21 +40,38 @@ const MediaViewerPopup: React.FC<MediaViewerPopupProps> = ({
   // Filter media items to only show those marked for popup display
   const popupMediaItems = mediaItems.filter(item => item.showInViewer !== false);
 
-  // Navigation functions defined early to be used in useEffect hooks
-  const navigatePrev = () => {
+  // Fullscreen functionality
+  const enterFullscreen = React.useCallback(() => {
+    if (containerRef.current) {
+      if (containerRef.current.requestFullscreen) {
+        containerRef.current.requestFullscreen();
+      }
+      setIsFullscreen(true);
+    }
+  }, []);
+
+  const exitFullscreen = React.useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+    setIsFullscreen(false);
+  }, []);
+
+  // Navigation functions defined as useCallback hooks to prevent recreation on every render
+  const navigatePrev = React.useCallback(() => {
     setCurrentIndex(prevIndex => {
       if (prevIndex === 0) return popupMediaItems.length - 1;
       return prevIndex - 1;
     });
-  };
+  }, [popupMediaItems.length]);
 
-  const navigateNext = () => {
+  const navigateNext = React.useCallback(() => {
     setCurrentIndex(prevIndex => (prevIndex + 1) % popupMediaItems.length);
-  };
+  }, [popupMediaItems.length]);
 
-  const togglePlayPause = () => {
-    setIsPlaying(!isPlaying);
-  };
+  const togglePlayPause = React.useCallback(() => {
+    setIsPlaying(prev => !prev);
+  }, []);
 
   // Find the displayFirst item and use its index among popup items
   useEffect(() => {
@@ -166,24 +183,9 @@ const MediaViewerPopup: React.FC<MediaViewerPopupProps> = ({
       document.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = 'unset';
     };
-  }, [isOpen, isFullscreen, onClose, popupMediaItems, currentIndex]);
+  }, [isOpen, isFullscreen, onClose, popupMediaItems, currentIndex, navigatePrev, navigateNext, togglePlayPause, enterFullscreen, exitFullscreen]);
 
-  // Fullscreen functionality
-  const enterFullscreen = () => {
-    if (containerRef.current) {
-      if (containerRef.current.requestFullscreen) {
-        containerRef.current.requestFullscreen();
-      }
-      setIsFullscreen(true);
-    }
-  };
-
-  const exitFullscreen = () => {
-    if (document.fullscreenElement) {
-      document.exitFullscreen();
-    }
-    setIsFullscreen(false);
-  };
+  // Fullscreen functionality has been moved to the top of the component
 
   // Handle fullscreen change events
   useEffect(() => {


### PR DESCRIPTION
This pull request refactors the navigation and control logic in both `MediaViewer` and `MediaViewerPopup` components to use `React.useCallback` hooks for all handler functions. This change ensures that the functions are stable between renders, which can help avoid unnecessary re-renders and potential bugs, especially when these handlers are passed as dependencies to `useEffect` hooks. Additionally, some fullscreen logic has been reorganized for clarity.

**Refactoring navigation and control handlers to use `useCallback`:**

* Converted navigation (`navigatePrev`, `navigateNext`), playback (`togglePlayPause`), mute (`toggleMute`), and fullscreen (`toggleFullscreen`) functions in `MediaViewer` to use `React.useCallback` for improved performance and stability. [[1]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL58-R79) [[2]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL84-R99) [[3]](diffhunk://#diff-f1fc0fe32c56df42a12f1a8acac251a833638360783620d96102e6906163b3dbL108-R114)
* Updated the keyboard navigation `useEffect` in `MediaViewer` to include the new stable handler functions as dependencies, ensuring correct behavior when these handlers change.
* Changed the indicator dot click handler in `MediaViewer` to use a new `goToIndex` callback, further improving consistency.

**Fullscreen and navigation enhancements in `MediaViewerPopup`:**

* Moved fullscreen functionality (`enterFullscreen`, `exitFullscreen`) to use `useCallback` and placed them at the top of the component for clarity.
* Refactored navigation (`navigatePrev`, `navigateNext`) and playback (`togglePlayPause`) handlers in `MediaViewerPopup` to use `useCallback`.
* Updated the main `useEffect` in `MediaViewerPopup` to include the new stable handler functions as dependencies and removed redundant fullscreen logic from inside the effect.