### PR TITLE
feat: Simplify NotFound component messaging and remove unnecessary links for a cleaner user experience

### DIFF
--- a/client/src/components/common/NotFound.tsx
+++ b/client/src/components/common/NotFound.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Link as ScrollLink } from 'react-scroll';
 import { motion, useMotionValue, useTransform, AnimatePresence } from 'framer-motion';
 import SEO from './SEO';
 import Header from '../layout/Header';
@@ -154,22 +153,8 @@ const NotFound: React.FC = () => {
               <Sparkles size={18} /> New Message
             </button>
           </div>
-          <div className="mt-12 grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm text-foreground/60 max-w-xl">
-            {['hero','about','skills','projects','education','contact'].map(anchor => (
-              <ScrollLink
-                key={anchor}
-                to={anchor}
-                smooth
-                duration={600}
-                offset={-80}
-                className="cursor-pointer px-3 py-2 rounded-md bg-background/40 dark:bg-background/30 hover:bg-background/70 dark:hover:bg-background/60 border border-border/30 backdrop-blur-md hover:text-primary transition-colors"
-              >
-                #{anchor}
-              </ScrollLink>
-            ))}
-          </div>
-          <div className="mt-10 flex items-center gap-2 text-xs text-foreground/40">
-            <ArrowLeft size={14} /> Try the links above or return home
+          <div className="mt-12 flex items-center gap-2 text-xs text-foreground/40">
+            <ArrowLeft size={14} /> You can head back home or generate a new message.
           </div>
         </div>
         <Footer />


### PR DESCRIPTION
This pull request simplifies the `NotFound` page by removing the section with scrollable anchor links and updating the guidance text for users. The most important changes are:

UI simplification and user guidance:

* Removed the grid of scrollable anchor links (`ScrollLink`) that allowed users to navigate to specific sections like `hero`, `about`, `skills`, etc., from the `NotFound` page.
* Updated the guidance message beneath the main content to suggest heading back home or generating a new message, instead of trying the links above.
* Removed the unused import of `ScrollLink` from `react-scroll` in `NotFound.tsx`.