### PR TITLE
feat: Comment out Footer component in NotFound for cleaner layout

### DIFF
--- a/client/src/components/common/NotFound.tsx
+++ b/client/src/components/common/NotFound.tsx
@@ -192,7 +192,7 @@ const NotFound: React.FC = () => {
             <ArrowLeft size={14} /> You can head back home or generate a new message.
           </div>
         </div>
-        <Footer />
+        {/* <Footer /> */}
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_30%,rgba(var(--color-primary)/0.12),transparent_60%),radial-gradient(circle_at_80%_70%,rgba(var(--color-secondary)/0.1),transparent_65%)]" />
         <div className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-40 dark:opacity-30" style={{ backgroundImage: 'linear-gradient(125deg, rgba(255,255,255,0.05) 0%, transparent 60%)' }} />
       </div>


### PR DESCRIPTION
This pull request includes a minor update to the `NotFound` component. The `Footer` component has been commented out, which will remove the footer from the Not Found page UI. 

- UI update:
  * Commented out the `Footer` component in `NotFound.tsx`, so the footer no longer appears on the Not Found page.