### PR TITLE
feat: Update mediaItems filtering in ProjectsSection and adjust MediaCarousel interval for improved functionality

### DIFF
--- a/client/src/components/sections/ProjectsSection.tsx
+++ b/client/src/components/sections/ProjectsSection.tsx
@@ -183,7 +183,7 @@ const ProjectsSection: React.FC = () => {
                   >
                     <div className="relative overflow-hidden">
                       <MediaCarousel 
-                        mediaItems={project.media?.filter(item => item.showInViewer !== false) || []}
+                        mediaItems={project.media || []}
                         fallbackImageUrl={project.imageUrl}
                         height="h-52 sm:h-48"
                         autoplay={true}

--- a/client/src/components/ui/MediaCarousel.tsx
+++ b/client/src/components/ui/MediaCarousel.tsx
@@ -17,7 +17,7 @@ const MediaCarousel: React.FC<MediaCarouselProps> = ({
   mediaItems = [], 
   fallbackImageUrl,
   autoplay = true,
-  interval = 5000,
+  interval = 7000,
   className = '',
   height = 'h-52',
   onViewMedia,


### PR DESCRIPTION
This pull request makes two minor adjustments to the project media display components. The interval for the media carousel's autoplay is increased, and the filtering of media items in the projects section is removed to display all media items.

- Media Carousel improvements:
  * Increased the autoplay interval in `MediaCarousel` from 5000ms to 7000ms, resulting in slower transitions between media items.

- Projects Section adjustments:
  * Removed the filter that excluded media items with `showInViewer === false` in `ProjectsSection`, so all media items associated with a project are now shown in the carousel.