### PR TITLE
feat: Add Netlify icon to iconMap for improved icon representation

### DIFF
--- a/client/src/components/ui/iconMap.tsx
+++ b/client/src/components/ui/iconMap.tsx
@@ -4,7 +4,7 @@ import {
     SiMongodb, SiMysql, SiCanva, SiFigma, SiAdobeillustrator, SiAdobephotoshop,
     SiVercel, SiRailway, SiTailwindcss, SiJavascript, SiChartdotjs,
     SiC, SiCplusplus, SiSharp, SiKotlin,
-    SiPostman, SiWordpress, SiTwilio
+    SiPostman, SiWordpress, SiTwilio, SiNetlify
 } from 'react-icons/si';
 
 import {
@@ -29,6 +29,7 @@ export const iconMap: Record<string, React.ComponentType<{ className?: string }>
     github: FaGithub,
     vercel: SiVercel,
     railway: SiRailway,
+    netlify: SiNetlify,
     docker: FaDocker,
     html: FaHtml5,
     css: SiCss3,


### PR DESCRIPTION
This pull request adds support for the Netlify icon in the application's icon mapping utility. The changes ensure that Netlify can be referenced and displayed alongside other supported platforms and technologies.

**Icon support updates:**

* Added `SiNetlify` to the list of imported icons from `react-icons/si` in `iconMap.tsx`.
* Added a `netlify` entry to the `iconMap` object, mapping it to the `SiNetlify` icon component.