### PR TITLE
feat: update SkillsSection layout and improve SemicircularFilters responsiveness

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -83,26 +83,31 @@ const SkillsSection: React.FC = () => {
             </div>
           ) : (
             <>
-              {/* Semicircular Category Filters */}
-              <SemicircularFilters
-                categories={categories}
-                activeCategory={activeCategory}
-                onCategorySelect={handleCategorySelect}
-              />
+              {/* Main Content Container */}
+              <div className="relative min-h-[600px] bg-card/30 rounded-xl overflow-hidden flex flex-col lg:flex-row">
+                {/* 3D Skills Sphere */}
+                <div className="flex-1 lg:flex-1">
+                  <Suspense fallback={
+                    <div className="flex justify-center items-center h-full">
+                      <Loader2 className="animate-spin h-10 w-10 text-primary" />
+                    </div>
+                  }>
+                    <SkillsSphere
+                      skills={skills}
+                      filteredSkills={filteredSkills}
+                      activeCategory={activeCategory}
+                    />
+                  </Suspense>
+                </div>
 
-              {/* 3D Skills Sphere */}
-              <div className="relative min-h-[600px] bg-card/30 rounded-xl overflow-hidden">
-                <Suspense fallback={
-                  <div className="flex justify-center items-center h-full">
-                    <Loader2 className="animate-spin h-10 w-10 text-primary" />
-                  </div>
-                }>
-                  <SkillsSphere
-                    skills={skills}
-                    filteredSkills={filteredSkills}
+                {/* Semicircular Category Filters - Right Side on Desktop, Bottom on Mobile */}
+                <div className="w-full lg:w-80 flex items-center justify-center lg:justify-start lg:pl-4 py-4 lg:py-0">
+                  <SemicircularFilters
+                    categories={categories}
                     activeCategory={activeCategory}
+                    onCategorySelect={handleCategorySelect}
                   />
-                </Suspense>
+                </div>
               </div>
             </>
           )}

--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -13,16 +13,17 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
   activeCategory,
   onCategorySelect,
 }) => {
-  const radius = 200; // Radius of the semicircle
+  const radius = 150; // Radius of the semicircle
   const centerX = 0;
   const centerY = 0;
 
-  // Calculate positions for each button along the semicircle
+  // Calculate positions for each button along the semicircle pointing right
   const getButtonPosition = (index: number, total: number) => {
-    // Distribute buttons along a semicircle (180 degrees)
-    const angle = (Math.PI * index) / (total - 1);
+    // Distribute buttons along a semicircle (180 degrees) starting from top going to bottom
+    // Rotate the semicircle to point to the right (open side towards page border)
+    const angle = (Math.PI * index) / (total - 1) - Math.PI / 2; // -90 to +90 degrees
     const x = centerX + radius * Math.cos(angle);
-    const y = centerY - radius * Math.sin(angle) + radius; // Flip and offset
+    const y = centerY + radius * Math.sin(angle);
     
     return { x, y, angle };
   };
@@ -38,8 +39,8 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
   };
 
   return (
-    <div className="relative w-full h-64 flex items-center justify-center mb-12">
-      <div className="relative" style={{ width: radius * 2 + 200, height: radius + 100 }}>
+    <div className="relative w-full h-full flex items-center justify-center">
+      <div className="relative" style={{ width: Math.min(radius + 100, 300), height: Math.min(radius * 2 + 100, 400) }}>
         {categories.map((category, index) => {
           const { x, y } = getButtonPosition(index, categories.length);
           const isActive = activeCategory === category;
@@ -47,14 +48,14 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
           return (
             <motion.button
               key={category}
-              className={`absolute px-6 py-3 rounded-full text-sm font-medium transition-all duration-300 transform -translate-x-1/2 -translate-y-1/2 ${
+              className={`absolute px-3 py-2 lg:px-4 lg:py-2 rounded-full text-xs lg:text-sm font-medium transition-all duration-300 transform -translate-x-1/2 -translate-y-1/2 ${
                 isActive
                   ? 'bg-primary text-white shadow-lg scale-110'
                   : 'bg-card hover:bg-card/80 text-foreground hover:scale-105'
               }`}
               style={{
-                left: x + radius + 100,
-                top: y + 50,
+                left: x + radius / 2 + 50,
+                top: y + radius + 50,
               }}
               onClick={() => handleCategoryClick(category)}
               initial={{ scale: 0, opacity: 0 }}
@@ -84,26 +85,41 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
           );
         })}
         
-        {/* Decorative semicircle line */}
+        {/* Visible semicircle circumference line */}
         <svg
-          className="absolute inset-0 pointer-events-none opacity-20"
+          className="absolute inset-0 pointer-events-none"
           width="100%"
           height="100%"
           style={{ left: 0, top: 0 }}
         >
           <defs>
-            <linearGradient id="semicircleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-              <stop offset="0%" stopColor="currentColor" stopOpacity="0.1" />
-              <stop offset="50%" stopColor="currentColor" stopOpacity="0.3" />
-              <stop offset="100%" stopColor="currentColor" stopOpacity="0.1" />
+            <linearGradient id="semicircleGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="currentColor" stopOpacity="0.6" />
+              <stop offset="50%" stopColor="currentColor" stopOpacity="0.8" />
+              <stop offset="100%" stopColor="currentColor" stopOpacity="0.6" />
             </linearGradient>
           </defs>
           <path
-            d={`M ${100} ${radius + 50} A ${radius} ${radius} 0 0 1 ${radius * 2 + 100} ${radius + 50}`}
+            d={`M ${radius / 2 + 50} ${50} A ${radius} ${radius} 0 0 1 ${radius / 2 + 50} ${radius * 2 + 50}`}
             stroke="url(#semicircleGradient)"
             strokeWidth="2"
             fill="none"
             className="text-primary"
+          />
+          {/* Add small dots at the endpoints */}
+          <circle 
+            cx={radius / 2 + 50} 
+            cy={50} 
+            r="3" 
+            fill="currentColor" 
+            className="text-primary opacity-60"
+          />
+          <circle 
+            cx={radius / 2 + 50} 
+            cy={radius * 2 + 50} 
+            r="3" 
+            fill="currentColor" 
+            className="text-primary opacity-60"
           />
         </svg>
       </div>

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -261,11 +261,9 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
       >
         <SphereScene {...props} />
         <OrbitControls 
-          enableZoom={true}
+          enableZoom={false}
           enablePan={false}
           autoRotate={false}
-          maxDistance={25}
-          minDistance={8}
           maxPolarAngle={Math.PI}
           minPolarAngle={0}
           dampingFactor={0.05}
@@ -273,9 +271,9 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
         />
       </Canvas>
       
-      {/* Loading overlay for better UX */}
-      <div className="absolute top-4 right-4 text-xs text-foreground/50">
-        Drag to rotate • Scroll to zoom
+      {/* User guidance */}
+      <div className="absolute top-4 left-4 text-xs text-foreground/50">
+        Drag to rotate
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request updates the layout and interactivity of the skills section, focusing on improving the usability and visual design of the semicircular category filters and the 3D skills sphere. The main changes include repositioning and restyling the category filters for better responsiveness, adjusting the semicircle's geometry and appearance, and simplifying the skills sphere controls.

**Skills Section Layout and Responsiveness:**

* The `SemicircularFilters` component is now placed on the right side of the skills section on desktop and at the bottom on mobile, wrapped in a flex container for better layout control. [[1]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdL86-R89) [[2]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdR102-R111)

**SemicircularFilters Visual Design and Geometry:**

* Reduced the semicircle radius from 200 to 150, adjusted button positioning logic so the semicircle opens to the right, and improved the sizing for responsiveness. [[1]](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL16-R26) [[2]](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL41-R58)
* Updated the semicircle's SVG: changed the gradient direction and opacity, adjusted the path to match the new geometry, and added decorative dots at the endpoints for visual clarity.

**Skills Sphere Controls and Guidance:**

* Disabled zooming on the 3D skills sphere for a simpler interaction, and updated the user guidance overlay to reflect the new controls ("Drag to rotate" only).