### PR TITLE
feat: adjust icon scaling in SkillNode component with maximum size cap

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -92,11 +92,13 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           textShadow: '0 0 4px rgba(0,0,0,0.8)',
           filter: isFiltered ? 'opacity(0.4)' : 'opacity(1)',
           transition: 'filter 0.3s ease',
-          transform: `scale(${Math.max(skill.proficiency * 0.15, 0.8)})` // Use proficiency for icon scaling
+          transform: `scale(${Math.min(Math.max(skill.proficiency * 0.08, 0.6), 1)})` // Proficiency scaling with max size cap
         }}
       >
         <div className="flex flex-col items-center">
-          <IconComponent className="text-lg mb-1" />
+          <div className="w-12 h-12 flex items-center justify-center">
+            <IconComponent className="w-full h-full max-w-[80px] max-h-[80px] mb-1" />
+          </div>
           <span className="text-xs">{skill.name}</span>
         </div>
       </Html>


### PR DESCRIPTION
This pull request makes a small adjustment to the visual scaling and layout of skill icons in the `SkillsSphere` component. The main change is to the scaling logic for icons based on proficiency and the layout structure to ensure consistent sizing.

- UI improvements to skill icon scaling and layout:
  * Updated the scaling formula for icons to use a capped range, ensuring icons are neither too small nor too large, and wrapped the icon in a fixed-size container for consistent display. (`client/src/components/ui/SkillsSphere.tsx`)