### PR TITLE
feat: update icon size calculation in SkillNode for improved scaling and adjust label font size

### DIFF
--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -98,7 +98,7 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
               
               {/* Label */}
               <motion.text
-                className="cursor-pointer select-none"
+                className={`cursor-pointer select-none ${isActive ? 'filter drop-shadow-lg' : ''}`}
                 x={labelX}
                 y={labelY}
                 textAnchor="end"
@@ -106,10 +106,13 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
                 style={{
                   fontSize: '18px',
                   fill: isActive ? cssVars.accent : cssVars.text,
-                  fontWeight: isActive ? 600 : 500
+                  fontWeight: isActive ? 600 : 500,
+                  paintOrder: 'stroke',
+                  stroke: isActive ? cssVars.accent : 'none',
+                  strokeWidth: isActive ? 0.5 : 0
                 }}
                 onClick={() => handleCategoryClick(category)}
-                whileHover={{ scale: 1.05 }}
+                whileHover={{ scale: 1.08 }}
                 initial={{ opacity: 0, x: -20 }}
                 animate={{ 
                   opacity: 1, 

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -76,8 +76,8 @@ const SkillNode: React.FC<SkillNodeProps> = ({
   if (!isVisible) return null;
 
   // Calculate icon size based on proficiency (min 32px, max 80px)
-  const minSize = 32;
-  const maxSize = 80;
+  const minSize = 40;
+  const maxSize = 96;
   // Assume proficiency is 0-100, normalize to 0-1
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
@@ -102,11 +102,9 @@ const SkillNode: React.FC<SkillNodeProps> = ({
       >
         <div className="flex flex-col items-center">
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <IconComponent 
-              className={`mb-1 w-[${iconSize}px] h-[${iconSize}px] max-w-[80px] max-h-[80px]`}
-            />
+            <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs">{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: Math.min(20, 12 + 8 * normalized) }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request updates the appearance and interactivity of the `SkillsSphere` and `SemicircularFilters` UI components to improve visual clarity and user experience. The main changes involve adjusting icon and label sizing, enhancing text styling, and refining hover effects.

**SkillsSphere visual improvements:**
- Increased the minimum and maximum icon sizes for skill nodes, making proficiency differences more visually distinct (`minSize` from 32→40, `maxSize` from 80→96).
- Simplified icon sizing in the `IconComponent` and made skill name font size responsive to proficiency, improving readability and visual scaling.

**SemicircularFilters label enhancements:**
- Enhanced active filter label appearance by adding a stroke, drop shadow, and stronger hover scaling for better emphasis and accessibility.