### PR TITLE
feat: adjust maximum icon size in SkillNode to improve visual consistency

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -77,7 +77,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
 
   // Calculate icon size based on proficiency (min 32px, max 80px)
   const minSize = 40;
-  const maxSize = 96;
+  const maxSize = 80;
   // Assume proficiency is 0-100, normalize to 0-1
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;


### PR DESCRIPTION
This pull request makes a minor adjustment to the sizing logic for skill icons in the `SkillsSphere` component. The maximum icon size has been reduced from 96px to 80px to better balance the visual appearance of skill nodes.