### PR TITLE
feat: adjust maximum icon size in SkillNode from 80px to 60px for improved consistency

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -75,9 +75,8 @@ const SkillNode: React.FC<SkillNodeProps> = ({
 
   if (!isVisible) return null;
 
-  // Calculate icon size based on proficiency (min 32px, max 80px)
   const minSize = 40;
-  const maxSize = 80;
+  const maxSize = 60;
   // Assume proficiency is 0-100, normalize to 0-1
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;


### PR DESCRIPTION
This pull request makes a minor adjustment to the `SkillsSphere` component by reducing the maximum icon size for skill nodes. This change will make the largest skill icons smaller and may improve the visual balance of the skill sphere.

* Reduced the maximum icon size for skill nodes in `SkillNode` from 80px to 60px to improve appearance.