### PR TITLE
feat: adjust icon size range in SkillNode for improved scaling and consistency

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -75,8 +75,8 @@ const SkillNode: React.FC<SkillNodeProps> = ({
 
   if (!isVisible) return null;
 
-  const minSize = 40;
-  const maxSize = 60;
+  const minSize = 28;
+  const maxSize = 44;
   // Assume proficiency is 0-100, normalize to 0-1
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
@@ -103,7 +103,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: Math.min(20, 12 + 8 * normalized) }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: Math.min(15, 10 + 5 * normalized) }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request makes visual adjustments to the `SkillNode` component in the `SkillsSphere.tsx` file to reduce the size of skill icons and their labels, resulting in a more compact and visually balanced display.

**Visual adjustments to skill nodes:**

* Reduced the minimum and maximum icon sizes by updating `minSize` from 40 to 28 and `maxSize` from 60 to 44, making skill icons smaller.
* Decreased the maximum font size for skill names and adjusted the scaling formula to make text labels more compact, changing the maximum from 20px to 15px and the scaling from `12 + 8 * normalized` to `10 + 5 * normalized`.