### PR TITLE
feat: adjust icon size range in SkillNode for improved visual consistency

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -75,8 +75,8 @@ const SkillNode: React.FC<SkillNodeProps> = ({
 
   if (!isVisible) return null;
 
-  const minSize = 28;
-  const maxSize = 44;
+  const minSize = 20;
+  const maxSize = 32;
   // Assume proficiency is 0-100, normalize to 0-1
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
@@ -103,7 +103,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: Math.min(15, 10 + 5 * normalized) }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: Math.min(12, 8 + 4 * normalized) }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request makes minor visual adjustments to the `SkillNode` component in `SkillsSphere.tsx`, reducing the size range of skill icons and their labels to achieve a more compact display.

- UI adjustments in `SkillNode`:
  * Decreased the minimum and maximum icon sizes from 28–44px to 20–32px for a smaller visual footprint.
  * Reduced the minimum and maximum font size for skill labels, making them slightly smaller and more consistent with the new icon sizes.