### PR TITLE
feat: add FilteredSkillsGrid component for displaying filtered skills

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -6,6 +6,7 @@ import { useApiService } from '../../hooks/useApiService';
 import { Loader2 } from 'lucide-react';
 import SkillsSphere from '../ui/SkillsSphere';
 import SemicircularFilters from '../ui/SemicircularFilters';
+import FilteredSkillsGrid from '../ui/FilteredSkillsGrid';
 
 const categories: SkillCategory[] = ['Frontend', 'Backend', 'Database', 'DevOps', 'Languages', 'Design', 'Other'];
 
@@ -85,8 +86,8 @@ const SkillsSection: React.FC = () => {
             <>
               {/* Main Content Container */}
               <div className="relative min-h-[600px] bg-card/30 rounded-xl overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
-                {/* 3D Skills Sphere - Reduced width */}
-                <div className="flex-1 lg:flex-none lg:w-2/3" style={{ zIndex: 1 }}>
+                {/* 3D Skills Sphere - Reduced width, blur/fade when filtered */}
+                <div className={`flex-1 lg:flex-none lg:w-2/3 transition-all duration-500 ${activeCategory ? 'blur-sm brightness-75 grayscale-[0.3] pointer-events-none' : ''}`} style={{ zIndex: 1 }}>
                   <Suspense fallback={
                     <div className="flex justify-center items-center h-full">
                       <Loader2 className="animate-spin h-10 w-10 text-primary" />
@@ -108,6 +109,11 @@ const SkillsSection: React.FC = () => {
                     onCategorySelect={handleCategorySelect}
                   />
                 </div>
+
+                {/* Filtered Skills Grid Overlay */}
+                {activeCategory && (
+                  <FilteredSkillsGrid skills={filteredSkills} onClose={() => setActiveCategory(null)} />
+                )}
               </div>
             </>
           )}

--- a/client/src/components/ui/FilteredSkillsGrid.tsx
+++ b/client/src/components/ui/FilteredSkillsGrid.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Skill } from '../../types';
+import { iconMap } from './iconMap';
+
+interface FilteredSkillsGridProps {
+  skills: Skill[];
+  onClose: () => void;
+}
+
+const getIconComponent = (iconName: string) => {
+  if (!iconName) return iconMap['default'];
+  const normalizedName = iconName.toLowerCase().trim();
+  if (iconMap[normalizedName]) return iconMap[normalizedName];
+  return iconMap['default'];
+};
+
+const FilteredSkillsGrid: React.FC<FilteredSkillsGridProps> = ({ skills, onClose }) => {
+  return (
+    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/10 backdrop-blur-[8px]">
+      <div className="w-full flex justify-end px-8 pt-8">
+        <button
+          className="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-primary font-semibold shadow-lg backdrop-blur border border-white/20"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+      <div className="w-full max-w-5xl mx-auto grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-8 p-8 rounded-2xl glassmorph shadow-2xl" style={{background: 'rgba(30,40,60,0.35)', border: '1.5px solid rgba(255,255,255,0.08)'}}>
+        {skills.map(skill => {
+          const Icon = getIconComponent(skill.icon);
+          return (
+            <div key={skill.name} className="flex flex-col items-center justify-center p-4 rounded-xl bg-white/10 backdrop-blur-[2px] border border-white/10 shadow-md glassmorph transition-transform hover:scale-105">
+              <Icon className="mb-2 w-10 h-10 text-primary" />
+              <span className="text-base font-medium text-white/90 text-center" style={{textShadow: '0 1px 8px #0008'}}>{skill.name}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default FilteredSkillsGrid;


### PR DESCRIPTION
This pull request enhances the `SkillsSection` component by introducing a new overlay grid for filtered skills, improving the user experience when browsing skills by category. The main changes include adding a new `FilteredSkillsGrid` component, updating the UI to display this grid as an overlay, and visually dimming the 3D skills sphere when a filter is active.

**UI/UX Improvements:**

* Added a new `FilteredSkillsGrid` component that displays filtered skills in a responsive grid overlay when a skill category is selected. The grid includes a close button to exit the overlay. (`client/src/components/ui/FilteredSkillsGrid.tsx`)
* Updated the skills sphere container to blur, dim, and disable pointer events when a category filter is active, providing a clear focus on the filtered grid. (`client/src/components/sections/SkillsSection.tsx`)

**Component Integration:**

* Imported and integrated the new `FilteredSkillsGrid` component into the `SkillsSection`, rendering it conditionally based on the active filter state. (`client/src/components/sections/SkillsSection.tsx`) [[1]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdR9) [[2]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdR112-R116)