### PR TITLE
feat: update SkillsSphere to conditionally display skills based on active category

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -95,7 +95,7 @@ const SkillsSection: React.FC = () => {
                       </div>
                     }>
                       <SkillsSphere
-                        skills={skills}
+                        skills={activeCategory ? skills.filter(skill => !filteredSkills.includes(skill)) : skills}
                         filteredSkills={filteredSkills}
                         activeCategory={activeCategory}
                       />


### PR DESCRIPTION
This pull request makes a targeted update to the `SkillsSection` component to improve how skills are displayed when a category is selected. The change ensures that when an `activeCategory` is present, the `SkillsSphere` only receives skills that are not already filtered out, leading to a more accurate and relevant display for the user.

- Updated the `SkillsSphere` props so that when an `activeCategory` is selected, only skills not in `filteredSkills` are passed, improving the filtering logic in the skills visualization.