### PR TITLE
fix: comment out conditional rendering for filtered skills overlay in SkillsSection

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -102,7 +102,7 @@ const SkillsSection: React.FC = () => {
                     </Suspense>
                   </div>
                   {/* Filtered Grid Overlay */}
-                  {activeCategory && (
+                  {/* {activeCategory && (
                     <motion.div
                       initial={{ opacity: 0, y: 40 }}
                       animate={{ opacity: 1, y: 0 }}
@@ -126,7 +126,7 @@ const SkillsSection: React.FC = () => {
                         })}
                       </div>
                     </motion.div>
-                  )}
+                  )} */}
                 </div>
 
                 {/* Semicircular Category Filters - Increased width */}


### PR DESCRIPTION
This pull request makes a small change to the `SkillsSection` component by commenting out the overlay that displays filtered skills when a category is active. No other functionality is affected. [[1]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdL105-R105) [[2]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdL129-R129)