### PR TITLE
feat: arrange filtered skills in a horizontal arc in front of the sphere

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -147,25 +147,24 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
     return positions;
   }, [skills]);
 
-  // Generate positions for separated skills (in front)
+  // Arrange filtered skills in a horizontal arc in front of the sphere
   const separatedPositions = useMemo(() => {
     const positions: Array<{ skill: Skill; position: [number, number, number] }> = [];
-    const gridSize = Math.ceil(Math.sqrt(filteredSkills.length));
-    const spacing = 2; // Reduced spacing to match smaller sphere
-    
-    filteredSkills.forEach((skill, index) => {
-      const row = Math.floor(index / gridSize);
-      const col = index % gridSize;
-      const x = (col - (gridSize - 1) / 2) * spacing;
-      const y = (row - (gridSize - 1) / 2) * spacing;
-      const z = 8; // Reduced from 10 to move closer
-      
-      positions.push({
-        skill,
-        position: [x, y, z]
+    const arcRadius = 3.5; // Distance from center (same as sphere radius)
+    const z = 6; // Fixed Z in front of sphere
+    const count = filteredSkills.length;
+    if (count === 1) {
+      positions.push({ skill: filteredSkills[0], position: [0, 0, z] });
+    } else {
+      const arcAngle = Math.PI / 1.3; // Spread arc (radians), adjust for more/less spread
+      const startAngle = -arcAngle / 2;
+      filteredSkills.forEach((skill, i) => {
+        const angle = startAngle + (arcAngle * (i / (count - 1)));
+        const x = Math.sin(angle) * arcRadius;
+        const y = Math.cos(angle) * arcRadius * -0.5; // Slight vertical curve
+        positions.push({ skill, position: [x, y, z] });
       });
-    });
-    
+    }
     return positions;
   }, [filteredSkills]);
 


### PR DESCRIPTION
This pull request updates the way filtered skills are arranged in the `SkillsSphere` component. Instead of laying out the filtered skills in a grid, they are now positioned along a horizontal arc in front of the sphere for a more visually appealing and focused display.

**UI/UX Improvements:**

* [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L150-R167): Changed the arrangement of filtered skills from a grid layout to a horizontal arc in front of the sphere, improving clarity and aesthetics. The arc's spread and position are dynamically calculated based on the number of filtered skills.