### PR TITLE
feat: reduce spacing between icons and rows in SkillsSphere layout

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -157,8 +157,8 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
     const maxCols = count <= 4 ? count : count <= 8 ? 4 : 6;
     const cols = Math.min(maxCols, count);
     const rows = Math.ceil(count / cols);
-    const spacingX = 2.2; // Horizontal spacing between icons
-    const spacingY = 2.2; // Vertical spacing between rows
+  const spacingX = 1.2; // Horizontal spacing between icons (reduced)
+  const spacingY = 1.4; // Vertical spacing between rows (reduced)
     for (let i = 0; i < count; i++) {
       const row = Math.floor(i / cols);
       const col = i % cols;


### PR DESCRIPTION
This pull request makes a small adjustment to the layout of skill icons in the `SkillsSphere` component. The horizontal and vertical spacing between icons has been reduced to make the arrangement more compact.

- Reduced `spacingX` and `spacingY` values to decrease the horizontal and vertical spacing between skill icons in `SkillsSphere.tsx`.