### PR TITLE
feat: enhance line height for skill names in SkillNode component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -99,7 +99,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized) }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? 1 : undefined }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request introduces a small UI improvement to the `SkillNode` component in `SkillsSphere.tsx`. The change adjusts the line height of the skill name label when the node is displayed in a separated state, ensuring better visual alignment.

- UI adjustment:
  * [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L102-R102): Sets the `lineHeight` to `1` for the skill name label when `isSeparated` is true, improving text appearance for separated nodes.