### PR TITLE
fix: update line height for skill names in SkillNode component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -99,7 +99,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? 1 : undefined }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? '1em' : undefined }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request makes a minor adjustment to the `SkillNode` component in `SkillsSphere.tsx` to improve the consistency of text rendering. The change ensures that the `lineHeight` CSS property is always set to a valid unit, which can help with layout consistency across browsers.

* Updated the `lineHeight` style for the skill name `<span>` in `SkillNode` to use `'1em'` instead of a unitless value when `isSeparated` is false.