### PR TITLE
fix: adjust line height for skill names in SkillNode component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -99,7 +99,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? '1em' : undefined }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? '1.15em' : undefined }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request makes a minor adjustment to the `SkillNode` component in `SkillsSphere.tsx` to improve the visual consistency of skill labels. The change sets the `lineHeight` CSS property to `'1.15em'` for all skill labels except when `isSeparated` is true, ensuring better alignment and readability.

- UI improvement:
  * [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L102-R102): Updated the `lineHeight` style for skill labels in the `SkillNode` component to use `'1.15em'` when not separated, enhancing text alignment and appearance.