### PR TITLE
feat: add background panel for filtered skills in SkillsSphere component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -218,6 +218,23 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
       
       {/* Separated filtered skills */}
       <group ref={separatedGroupRef}>
+        {/* Background panel for filtered skills */}
+        {activeCategory && filteredSkills.length > 0 && (
+          <mesh position={[0, 0, 5.9]}>
+            <planeGeometry args={[
+              // Width and height based on grid size
+              (Math.min(6, Math.max(4, filteredSkills.length)) * 0.9) + 1.2, 
+              (Math.ceil(filteredSkills.length / (filteredSkills.length <= 8 ? 4 : 6)) * 1.1) + 1.2
+            ]} />
+            <meshBasicMaterial 
+              color="#1e293b" 
+              transparent={true} 
+              opacity={0.7} 
+              side={THREE.DoubleSide} 
+            />
+          </mesh>
+        )}
+        
         {activeCategory && separatedPositions.map(({ skill, position }) => (
           <SkillNode
             key={`separated-${skill.id}`}


### PR DESCRIPTION
This pull request enhances the `SkillsSphere` component by improving the visual presentation of filtered skills. Specifically, it adds a dynamic background panel behind the filtered skills grid, making it easier for users to distinguish filtered skills from the rest.

**UI Improvements:**

* Added a semi-transparent background panel (`mesh` with `planeGeometry` and `meshBasicMaterial`) behind the filtered skills grid in `SkillsSphere.tsx`. The panel's size adjusts based on the number of filtered skills, and it appears only when a category is active and there are filtered skills to display.