### PR TITLE
UI ux seo

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -77,6 +77,11 @@ const SkillNode: React.FC<SkillNodeProps> = ({
   const maxSize = isSeparated ? 16 : 32;
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
+  
+  // Add padding for background
+  const paddingSize = isSeparated ? 5 : 0;
+  const containerSize = iconSize + (paddingSize * 2);
+  
   return (
     <mesh ref={meshRef} position={position}>
       <Html
@@ -96,10 +101,27 @@ const SkillNode: React.FC<SkillNodeProps> = ({
         }}
       >
         <div className="flex flex-col items-center">
-          <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div 
+            style={{ 
+              width: containerSize,
+              height: containerSize,
+              padding: paddingSize,
+              display: 'flex', 
+              alignItems: 'center', 
+              justifyContent: 'center',
+              backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent', // Background color for filtered skills
+              borderRadius: '50%', // Round background
+            }}
+          >
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? '1.15em' : undefined }}>{skill.name}</span>
+          <span className="text-xs" style={{ 
+            fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), 
+            lineHeight: isSeparated ? '1.15em' : undefined,
+            backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent',
+            padding: isSeparated ? '2px 4px' : 0,
+            borderRadius: isSeparated ? '4px' : 0
+          }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -218,23 +218,6 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
       
       {/* Separated filtered skills */}
       <group ref={separatedGroupRef}>
-        {/* Background panel for filtered skills */}
-        {activeCategory && filteredSkills.length > 0 && (
-          <mesh position={[0, 0, 5.9]}>
-            <planeGeometry args={[
-              // Width and height based on grid size
-              (Math.min(6, Math.max(4, filteredSkills.length)) * 0.9) + 1.2, 
-              (Math.ceil(filteredSkills.length / (filteredSkills.length <= 8 ? 4 : 6)) * 1.1) + 1.2
-            ]} />
-            <meshBasicMaterial 
-              color="#1e293b" 
-              transparent={true} 
-              opacity={0.7} 
-              side={THREE.DoubleSide} 
-            />
-          </mesh>
-        )}
-        
         {activeCategory && separatedPositions.map(({ skill, position }) => (
           <SkillNode
             key={`separated-${skill.id}`}


### PR DESCRIPTION
This pull request updates the appearance of skill nodes in the `SkillsSphere` component to improve visual clarity, especially when skills are filtered by category. The main changes involve removing the separate background panel for filtered skills and instead adding background styling directly to individual skill nodes and their labels.

**UI/UX improvements for filtered/selected skills:**

* Added background color, padding, and rounded borders to individual skill icons (`SkillNode`) when `isSeparated` is true, making filtered skills stand out without needing a separate background panel. [[1]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4R80-R84) [[2]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L99-R124)
* Applied similar background styling and padding to skill name labels for filtered skills, improving readability.

**Code simplification:**

* Removed the background panel mesh for filtered skills from the `SphereScene` group, as this is now handled at the node level.