### PR TITLE
UI ux seo

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -95,7 +95,15 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           transition: 'filter 0.3s ease',
         }}
       >
-        <div className="flex flex-col items-center">
+        <div 
+          className="flex flex-col items-center"
+          style={{
+            backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent',
+            borderRadius: isSeparated ? '12px' : '0',
+            padding: isSeparated ? '8px' : '0',
+            border: isSeparated ? '1px solid rgba(100, 116, 139, 0.3)' : 'none',
+          }}
+        >
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -77,11 +77,6 @@ const SkillNode: React.FC<SkillNodeProps> = ({
   const maxSize = isSeparated ? 16 : 32;
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
-  
-  // Add padding for background
-  const paddingSize = isSeparated ? 5 : 0;
-  const containerSize = iconSize + (paddingSize * 2);
-  
   return (
     <mesh ref={meshRef} position={position}>
       <Html
@@ -101,27 +96,10 @@ const SkillNode: React.FC<SkillNodeProps> = ({
         }}
       >
         <div className="flex flex-col items-center">
-          <div 
-            style={{ 
-              width: containerSize,
-              height: containerSize,
-              padding: paddingSize,
-              display: 'flex', 
-              alignItems: 'center', 
-              justifyContent: 'center',
-              backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent', // Background color for filtered skills
-              borderRadius: '50%', // Round background
-            }}
-          >
+          <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconComponent className="mb-1 w-full h-full" />
           </div>
-          <span className="text-xs" style={{ 
-            fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), 
-            lineHeight: isSeparated ? '1.15em' : undefined,
-            backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent',
-            padding: isSeparated ? '2px 4px' : 0,
-            borderRadius: isSeparated ? '4px' : 0
-          }}>{skill.name}</span>
+          <span className="text-xs" style={{ fontSize: isSeparated ? 5 : Math.min(12, 8 + 4 * normalized), lineHeight: isSeparated ? '1.15em' : undefined }}>{skill.name}</span>
         </div>
       </Html>
     </mesh>


### PR DESCRIPTION
This pull request refines the styling and layout logic for skill nodes in the `SkillsSphere` component, particularly when skills are displayed in a "separated" state. The changes simplify the calculation of container sizes and update how backgrounds, borders, and padding are applied, resulting in a cleaner and more consistent appearance.

Styling and layout improvements for separated skill nodes:

* Removed the calculation of `containerSize` and `paddingSize`, and instead applied padding, border, and border-radius directly via inline styles when `isSeparated` is true.
* Updated the background, border, and padding logic for the skill icon container, and added a wrapper div for the icon to ensure proper sizing and alignment.
* Simplified the skill name's styling by removing redundant background and border-radius logic, relying on the container's styles for visual separation.