### PR TITLE
fix: adjust border radius and padding for separated skills in SkillNode component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -99,8 +99,8 @@ const SkillNode: React.FC<SkillNodeProps> = ({
           className="flex flex-col items-center"
           style={{
             backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent',
-            borderRadius: isSeparated ? '12px' : '0',
-            padding: isSeparated ? '8px' : '0',
+            borderRadius: isSeparated ? '6px' : '0',
+            padding: isSeparated ? '4px' : '0',
             border: isSeparated ? '1px solid rgba(100, 116, 139, 0.3)' : 'none',
           }}
         >


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `SkillNode` component in `SkillsSphere.tsx`, reducing the border radius and padding when the node is separated. This results in a slightly more compact and subtle appearance for separated skill nodes.

- Reduced `borderRadius` from `12px` to `6px` and `padding` from `8px` to `4px` for separated skill nodes in the `SkillNode` component (`client/src/components/ui/SkillsSphere.tsx`).