### PR TITLE
fix: update background color, border, and add backdrop filter for separated skills in SkillNode component

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -98,10 +98,12 @@ const SkillNode: React.FC<SkillNodeProps> = ({
         <div 
           className="flex flex-col items-center"
           style={{
-            backgroundColor: isSeparated ? 'rgba(30, 41, 59, 0.7)' : 'transparent',
+            backgroundColor: isSeparated ? 'rgba(255, 255, 255, 0.15)' : 'transparent',
             borderRadius: isSeparated ? '6px' : '0',
             padding: isSeparated ? '4px' : '0',
-            border: isSeparated ? '1px solid rgba(100, 116, 139, 0.3)' : 'none',
+            border: isSeparated ? '1px solid rgba(255, 255, 255, 0.25)' : 'none',
+            backdropFilter: isSeparated ? 'blur(8px)' : 'none',
+            boxShadow: isSeparated ? '0 4px 6px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.1)' : 'none',
           }}
         >
           <div style={{ width: iconSize, height: iconSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>


### PR DESCRIPTION
This pull request updates the visual styling of separated skill nodes in the `SkillsSphere` component to enhance their appearance with a more modern, glass-like effect.

**UI/Styling Improvements:**

* Updated the `SkillNode` component's styling to use a semi-transparent white background, lighter border, blur effect, and subtle box shadow for separated nodes, replacing the previous dark background and border. (`client/src/components/ui/SkillsSphere.tsx`)