### PR TITLE
fix: add background styling to SemicircularFilters and SkillsSphere components

### DIFF
--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -39,7 +39,7 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full" style={{ height: '560px', overflow: 'hidden' }}>
+    <div className="relative w-full h-full bg-card/30 rounded-xl" style={{ height: '560px', overflow: 'hidden' }}>
       <svg className="w-full h-full block" viewBox="0 0 360 560">
         {/* Arc with glow effect */}
         <g className="arc-group">

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -259,7 +259,8 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
     <div className="w-full h-[600px] relative" style={{ zIndex: 1 }}>
       <Canvas
         camera={{ position: [0, 0, 10], fov: 50 }} // Moved closer from 12 to 10 for smaller sphere
-        style={{ background: 'transparent', zIndex: 1 }}
+        className="bg-card/30" // Using Tailwind bg-card class with 30% opacity
+        style={{ zIndex: 1 }}
         dpr={[1, 2]} // Responsive pixel ratio for performance
         performance={{ min: 0.5 }} // Performance monitoring
       >


### PR DESCRIPTION
This pull request introduces minor visual improvements to the UI components by updating background styles for better consistency and aesthetics.

Visual/UI enhancements:

* [`client/src/components/ui/SemicircularFilters.tsx`](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL42-R42): Added a semi-transparent card-style background (`bg-card/30`) and rounded corners (`rounded-xl`) to the main container for improved appearance.
* [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L262-R263): Applied a semi-transparent card-style background (`bg-card/30`) to the 3D canvas using a Tailwind class for a more cohesive look.