### PR TITLE
fix: remove background opacity from SemicircularFilters and SkillsSphere components

### DIFF
--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -39,7 +39,7 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full bg-card/30 rounded-xl" style={{ height: '560px', overflow: 'hidden' }}>
+    <div className="relative w-full h-full" style={{ height: '560px', overflow: 'hidden' }}>
       <svg className="w-full h-full block" viewBox="0 0 360 560">
         {/* Arc with glow effect */}
         <g className="arc-group">

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -259,8 +259,7 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
     <div className="w-full h-[600px] relative" style={{ zIndex: 1 }}>
       <Canvas
         camera={{ position: [0, 0, 10], fov: 50 }} // Moved closer from 12 to 10 for smaller sphere
-        className="bg-card/30" // Using Tailwind bg-card class with 30% opacity
-        style={{ zIndex: 1 }}
+        style={{ background: 'transparent', zIndex: 1 }}
         dpr={[1, 2]} // Responsive pixel ratio for performance
         performance={{ min: 0.5 }} // Performance monitoring
       >


### PR DESCRIPTION
This pull request makes minor visual adjustments to two UI components to improve their appearance and layering. The changes primarily remove background styles to achieve a cleaner, more transparent look.

UI and styling updates:

* [`client/src/components/ui/SemicircularFilters.tsx`](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL42-R42): Removed the `bg-card/30 rounded-xl` Tailwind classes from the container `div` to eliminate the background color and rounded corners, resulting in a fully transparent background.
* [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L262-R262): Changed the `Canvas` component's background from a semi-transparent Tailwind class to a fully transparent inline style, ensuring no background color is rendered.