### PR TITLE
fix: add dynamic background for active category labels in Semicircular Filters component

### DIFF
--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -96,7 +96,25 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
                 transition={{ duration: 0.2 }}
               />
               
-              {/* Label with dynamic background for active state */}
+              {/* Background for active label */}
+              {isActive && (
+                <rect
+                  x={labelX - (category.length * 9 + 16)} // Dynamic width based on text length
+                  y={labelY - 14} // Center vertically
+                  width={category.length * 9 + 16} // Dynamic width: ~9px per character + padding
+                  height={28} // Height of the background
+                  rx={10} // Rounded corners
+                  ry={10}
+                  style={{
+                    fill: 'rgba(47, 123, 255, 0.15)',
+                    stroke: 'rgba(47, 123, 255, 0.4)',
+                    strokeWidth: 1,
+                    pointerEvents: 'none'
+                  }}
+                />
+              )}
+              
+              {/* Label */}
               <motion.text
                 className={`cursor-pointer select-none ${isActive ? 'filter drop-shadow-lg' : ''}`}
                 x={labelX}
@@ -109,11 +127,7 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
                   fontWeight: isActive ? 600 : 500,
                   paintOrder: 'stroke',
                   stroke: isActive ? cssVars.accent : 'none',
-                  strokeWidth: isActive ? 0.5 : 0,
-                  padding: isActive ? '6px 12px' : '0',
-                  background: isActive ? 'rgba(47, 123, 255, 0.15)' : 'transparent',
-                  borderRadius: isActive ? '10px' : '0',
-                  border: isActive ? '1px solid rgba(47, 123, 255, 0.4)' : 'none',
+                  strokeWidth: isActive ? 0.5 : 0
                 }}
                 onClick={() => handleCategoryClick(category)}
                 whileHover={{ scale: 1.08 }}


### PR DESCRIPTION
This pull request updates the `SemicircularFilters` component to improve the appearance and clarity of active filter labels. The main change is the separation of the label's background into its own SVG `rect` element, allowing for more precise styling and dynamic sizing based on the label text.

**UI/Styling Improvements:**

* Added a dynamic SVG `rect` as a background for active filter labels, with width calculated based on the label text length for better visual alignment. The background uses a semi-transparent accent color and rounded corners. (`client/src/components/ui/SemicircularFilters.tsx`, [client/src/components/ui/SemicircularFilters.tsxL99-R117](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL99-R117))
* Removed inline background, border, border radius, and padding styles from the text label itself, since these are now handled by the separate background element. (`client/src/components/ui/SemicircularFilters.tsx`, [client/src/components/ui/SemicircularFilters.tsxL112-R130](diffhunk://#diff-9aec9787f0abfd20246c188a95ccd73c20671613004cf42b3bee5f6b7472079eL112-R130))