### PR TITLE
fix: adjust active label background position and width for better text containment in SemicircularFilters component

### DIFF
--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -99,9 +99,9 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
               {/* Background for active label */}
               {isActive && (
                 <rect
-                  x={labelX - (category.length * 9 + 16)} // Dynamic width based on text length
+                  x={labelX - (category.length * 9 + 22)} // Adjusted position (+6) to move rectangle rightward
                   y={labelY - 14} // Center vertically
-                  width={category.length * 9 + 16} // Dynamic width: ~9px per character + padding
+                  width={category.length * 9 + 24} // Increased width by 8px for better text containment
                   height={28} // Height of the background
                   rx={10} // Rounded corners
                   ry={10}


### PR DESCRIPTION
This pull request makes a minor adjustment to the label background in the `SemicircularFilters` component. The change slightly increases the width and shifts the background rectangle to better contain the label text, improving visual alignment and appearance.

- Adjusted the `x` position and `width` of the background rectangle for active labels in `SemicircularFilters.tsx` to better fit and center the text.