### PR TITLE
fix: reduce height of main content containers for improved layout consistency

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -85,7 +85,7 @@ const SkillsSection: React.FC = () => {
           ) : (
             <>
               {/* Main Content Container */}
-              <div className="relative min-h-[500px] bg-card rounded-xl shadow-lg p-6 md:p-8 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
+              <div className="relative min-h-[470px] bg-card rounded-xl shadow-lg p-5 md:p-7 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
                 {/* 3D Skills Sphere - Reduced width */}
                 <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto" style={{ zIndex: 1 }}>
                   <div className={activeCategory ? "transition-all duration-500 opacity-80" : "transition-all duration-500"}>

--- a/client/src/components/ui/SemicircularFilters.tsx
+++ b/client/src/components/ui/SemicircularFilters.tsx
@@ -39,8 +39,8 @@ const SemicircularFilters: React.FC<SemicircularFiltersProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full" style={{ height: '460px', overflow: 'hidden' }}>
-      <svg className="w-full h-full block" viewBox="0 0 360 460">
+    <div className="relative w-full h-full bg-card/30 rounded-xl" style={{ height: '430px', overflow: 'hidden' }}>
+      <svg className="w-full h-full block" viewBox="0 0 360 430">
         {/* Arc with glow effect */}
         <g className="arc-group">
           <path 

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -252,14 +252,14 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
   
   if (skills.length === 0) {
     return (
-      <div className="w-full h-[500px] flex items-center justify-center text-foreground/70">
+      <div className="w-full h-[470px] flex items-center justify-center text-foreground/70">
         <p>No skills available to display</p>
       </div>
     );
   }
 
   return (
-    <div className="w-full h-[500px] relative" style={{ zIndex: 1 }}>
+    <div className="w-full h-[470px] relative" style={{ zIndex: 1 }}>
       <Canvas
         camera={{ position: [0, 0, 10], fov: 50 }} // Moved closer from 12 to 10 for smaller sphere
         style={{ background: 'transparent', zIndex: 1 }}


### PR DESCRIPTION
This pull request makes several small UI adjustments to the skills section and related components to improve visual consistency and layout. The primary focus is on reducing the height of containers and updating padding, which should help the section feel more compact and visually balanced.

Layout and Styling Adjustments:

* Reduced the minimum height and padding of the main skills section container in `SkillsSection.tsx` from 500px to 470px and adjusted paddings for a tighter layout.
* Decreased the height of the semicircular filters container and SVG in `SemicircularFilters.tsx` from 460px to 430px, and added a semi-transparent card background with rounded corners for better visual integration.
* Updated the `SkillsSphere` component to use a height of 470px instead of 500px for both the empty state and the main sphere container, ensuring consistency with the rest of the section.