### PR TITLE
fix: reduce height of main content containers in SkillsSection and SkillsSphere for improved layout consistency

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -85,7 +85,7 @@ const SkillsSection: React.FC = () => {
           ) : (
             <>
               {/* Main Content Container */}
-              <div className="relative min-h-[470px] bg-card rounded-xl shadow-lg p-5 md:p-7 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
+              <div className="relative min-h-[450px] bg-card rounded-xl shadow-lg p-4 md:p-6 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
                 {/* 3D Skills Sphere - Reduced width */}
                 <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto" style={{ zIndex: 1 }}>
                   <div className={activeCategory ? "transition-all duration-500 opacity-80" : "transition-all duration-500"}>

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -252,14 +252,14 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
   
   if (skills.length === 0) {
     return (
-      <div className="w-full h-[470px] flex items-center justify-center text-foreground/70">
+      <div className="w-full h-[450px] flex items-center justify-center text-foreground/70">
         <p>No skills available to display</p>
       </div>
     );
   }
 
   return (
-    <div className="w-full h-[470px] relative" style={{ zIndex: 1 }}>
+    <div className="w-full h-[450px] relative" style={{ zIndex: 1 }}>
       <Canvas
         camera={{ position: [0, 0, 10], fov: 50 }} // Moved closer from 12 to 10 for smaller sphere
         style={{ background: 'transparent', zIndex: 1 }}


### PR DESCRIPTION
This pull request makes minor adjustments to the height and padding of the skills section and the skills sphere components to ensure consistent sizing and spacing in the UI.

UI consistency improvements:

* Reduced the minimum height of the main skills section container from 470px to 450px and slightly decreased its padding in `SkillsSection.tsx`.
* Updated the height of the skills sphere and its empty state from 470px to 450px in `SkillsSphere.tsx` to match the new section height.