### PR TITLE
fix: adjust font size in SkillNode for improved readability

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -108,7 +108,7 @@ const SkillNode: React.FC<SkillNodeProps> = ({
             <IconComponent className="mb-1 w-full h-full" />
           </div>
           <span className="text-xs" style={{ 
-            fontSize: isSeparated ? 4.5 : Math.min(11, 7.5 + 3.5 * normalized), 
+            fontSize: isSeparated ? 4 : Math.min(11, 7.5 + 3.5 * normalized), 
             lineHeight: isSeparated ? '1.1em' : '1.05em' 
           }}>{skill.name}</span>
         </div>


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `SkillNode` component in `SkillsSphere.tsx`. The font size for separated skill labels is slightly reduced for improved visual consistency.

- UI Adjustment:
  * [`client/src/components/ui/SkillsSphere.tsx`](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L111-R111): Reduced the font size for separated skill labels from 4.5 to 4 in the `SkillNode` component.