### PR TITLE
fix: adjust icon spacing in SkillsSphere for improved layout consistency

### DIFF
--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -164,8 +164,8 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
     const maxCols = count <= 4 ? count : count <= 8 ? 4 : 6;
     const cols = Math.min(maxCols, count);
     const rows = Math.ceil(count / cols);
-  const spacingX = 0.9; // Horizontal spacing between icons (tighter)
-  const spacingY = 1.1; // Vertical spacing between rows (tighter)
+  const spacingX = 1.0; // Horizontal spacing between icons (tighter)
+  const spacingY = 1.15; // Vertical spacing between rows (tighter)
     for (let i = 0; i < count; i++) {
       const row = Math.floor(i / cols);
       const col = i % cols;


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of the skills sphere by slightly increasing the horizontal and vertical spacing between icons. This change should improve the visual clarity and balance of the icon grid.

- Increased `spacingX` from 0.9 to 1.0 and `spacingY` from 1.1 to 1.15 in the `SphereScene` component to provide more space between icons.