### PR TITLE
fix: enhance responsiveness of SkillsSphere and SkillNode components for better mobile experience

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -86,8 +86,8 @@ const SkillsSection: React.FC = () => {
             <>
               {/* Main Content Container */}
               <div className="relative min-h-[450px] bg-card rounded-xl shadow-lg p-4 md:p-6 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
-                {/* 3D Skills Sphere - Reduced width */}
-                <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto" style={{ zIndex: 1 }}>
+                {/* 3D Skills Sphere - Responsive sizing */}
+                <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto h-[350px] sm:h-[380px] md:h-[400px] lg:h-[450px] px-2 md:px-4" style={{ zIndex: 1 }}>
                   <div className={activeCategory ? "transition-all duration-500 opacity-80" : "transition-all duration-500"}>
                     <Suspense fallback={
                       <div className="flex justify-center items-center h-full">


### PR DESCRIPTION
This pull request enhances the responsiveness and usability of the Skills Sphere 3D visualization, especially on mobile and tablet devices. The main changes involve making the sizing, spacing, and layout of the skills sphere and its nodes adapt dynamically to different screen sizes, improving the user experience across devices.

**Responsive sizing and layout for Skills Sphere and nodes:**

* The main container for the 3D Skills Sphere in `SkillsSection.tsx` now uses responsive height and padding classes to better fit various screen sizes.
* Skill node icon sizes in `SkillsSphere.tsx` are now calculated based on both the skill's proficiency and the current device size (mobile, tablet, desktop), resulting in more appropriate scaling across devices.
* The sphere radius and grid layout in `SphereScene` are now responsive, adjusting based on screen width and the number of skills to prevent overcrowding and maintain visual clarity on smaller screens. [[1]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L137-R151) [[2]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L163-R198)

**Performance and camera adjustments for mobile:**

* The camera position and field of view for the 3D Canvas are now dynamically set based on screen size, ensuring the sphere remains visible and centered on all devices. The device pixel ratio (dpr) is also reduced for improved performance on mobile.