### PR TITLE
Revert "fix: enhance responsiveness of SkillsSphere and SkillNode components for better mobile experience"  This reverts commit 7ace051c3b44e176dab23c9f042f1b46dcc06695.

### DIFF
--- a/client/src/components/sections/SkillsSection.tsx
+++ b/client/src/components/sections/SkillsSection.tsx
@@ -86,8 +86,8 @@ const SkillsSection: React.FC = () => {
             <>
               {/* Main Content Container */}
               <div className="relative min-h-[450px] bg-card rounded-xl shadow-lg p-4 md:p-6 overflow-hidden flex flex-col lg:flex-row" style={{ zIndex: 1 }}>
-                {/* 3D Skills Sphere - Responsive sizing */}
-                <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto h-[350px] sm:h-[380px] md:h-[400px] lg:h-[450px] px-2 md:px-4" style={{ zIndex: 1 }}>
+                {/* 3D Skills Sphere - Reduced width */}
+                <div className="flex-1 lg:flex-none lg:w-2/3 relative m-auto" style={{ zIndex: 1 }}>
                   <div className={activeCategory ? "transition-all duration-500 opacity-80" : "transition-all duration-500"}>
                     <Suspense fallback={
                       <div className="flex justify-center items-center h-full">

--- a/client/src/components/ui/SkillsSphere.tsx
+++ b/client/src/components/ui/SkillsSphere.tsx
@@ -71,21 +71,10 @@ const SkillNode: React.FC<SkillNodeProps> = ({
     }
   });
   if (!isVisible) return null;
-  
-  // Use responsive sizes based on screen width and filtered state
+  // Use much smaller size for separated (filtered) skills
   const isSeparated = position[2] === 6; // z=6 is the front grid
-  const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
-  const isTablet = typeof window !== 'undefined' && window.innerWidth >= 640 && window.innerWidth < 1024;
-  
-  // Adjust sizes for different screen sizes
-  const minSize = isSeparated 
-    ? (isMobile ? 8 : 10) 
-    : (isMobile ? 14 : isTablet ? 16 : 20);
-  
-  const maxSize = isSeparated 
-    ? (isMobile ? 12 : 16) 
-    : (isMobile ? 22 : isTablet ? 28 : 32);
-  
+  const minSize = isSeparated ? 10 : 20;
+  const maxSize = isSeparated ? 16 : 32;
   const normalized = Math.max(0, Math.min(1, skill.proficiency / 100));
   const iconSize = minSize + (maxSize - minSize) * normalized;
   return (
@@ -145,10 +134,7 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
   // Generate positions on a sphere using Fibonacci spiral
   const skillPositions = useMemo(() => {
     const positions: Array<{ skill: Skill; position: [number, number, number] }> = [];
-    // Use responsive radius based on skills count
-    const baseRadius = typeof window !== 'undefined' && window.innerWidth < 640 ? 2.8 : 3.5;
-    // Adjust radius based on number of skills to prevent overcrowding on small screens
-    const radius = Math.min(baseRadius, baseRadius * (20 / Math.max(skills.length, 1)));
+    const radius = 3.5; // Further reduced from 4.5 to 3.5
     const goldenAngle = Math.PI * (3 - Math.sqrt(5)); // Golden angle in radians
     
     skills.forEach((skill, index) => {
@@ -174,28 +160,12 @@ const SphereScene: React.FC<SkillsSphereProps> = ({
     const z = 6; // Fixed Z in front of sphere
     const count = filteredSkills.length;
     if (count === 0) return positions;
-    
-    // Responsive grid layout based on screen size
-    const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
-    const isTablet = typeof window !== 'undefined' && window.innerWidth >= 640 && window.innerWidth < 1024;
-    
-    // Choose columns per row based on device and count
-    let maxCols;
-    if (isMobile) {
-      maxCols = count <= 3 ? count : 3; // Max 3 columns on mobile
-    } else if (isTablet) {
-      maxCols = count <= 4 ? count : 4; // Max 4 columns on tablet
-    } else {
-      maxCols = count <= 4 ? count : count <= 8 ? 4 : 6; // 4-6 on desktop
-    }
-    
+    // Choose columns per row based on count (4-6 for desktop)
+    const maxCols = count <= 4 ? count : count <= 8 ? 4 : 6;
     const cols = Math.min(maxCols, count);
     const rows = Math.ceil(count / cols);
-    
-    // Adjust spacing based on screen size
-    const spacingX = isMobile ? 0.8 : 1.0; // Tighter horizontal spacing on mobile
-    const spacingY = isMobile ? 0.9 : 1.15; // Tighter vertical spacing on mobile
-    
+  const spacingX = 1.0; // Horizontal spacing between icons (tighter)
+  const spacingY = 1.15; // Vertical spacing between rows (tighter)
     for (let i = 0; i < count; i++) {
       const row = Math.floor(i / cols);
       const col = i % cols;
@@ -282,21 +252,18 @@ const SkillsSphere: React.FC<SkillsSphereProps> = (props) => {
   
   if (skills.length === 0) {
     return (
-      <div className="w-full h-full flex items-center justify-center text-foreground/70">
+      <div className="w-full h-[450px] flex items-center justify-center text-foreground/70">
         <p>No skills available to display</p>
       </div>
     );
   }
 
   return (
-    <div className="w-full h-full relative" style={{ zIndex: 1 }}>
+    <div className="w-full h-[450px] relative" style={{ zIndex: 1 }}>
       <Canvas
-        camera={{ 
-          position: [0, 0, window.innerWidth < 768 ? 12 : 10], 
-          fov: window.innerWidth < 640 ? 60 : 50 
-        }} // Adjust camera for mobile
+        camera={{ position: [0, 0, 10], fov: 50 }} // Moved closer from 12 to 10 for smaller sphere
         style={{ background: 'transparent', zIndex: 1 }}
-        dpr={[1, 1.5]} // Reduced for better mobile performance
+        dpr={[1, 2]} // Responsive pixel ratio for performance
         performance={{ min: 0.5 }} // Performance monitoring
       >
         <SphereScene {...props} />


### PR DESCRIPTION
This pull request simplifies and standardizes the sizing and layout logic for the 3D Skills Sphere component, removing most responsive (screen-size-based) adjustments in favor of fixed dimensions and spacing. The goal is to create a more consistent appearance across devices and reduce complexity in the sizing code.

**Skills Sphere Sizing and Layout Simplification:**

* Removed responsive sizing logic for the 3D sphere and skill icons, using fixed sizes and spacing instead. This affects the radius of the sphere, icon sizes, and grid layout for filtered skills, making the display more predictable and easier to maintain. [[1]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L74-R77) [[2]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L148-R137) [[3]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L177-R168)
* Updated the main container and Skills Sphere wrapper to use fixed heights (`h-[450px]`) rather than relying on responsive or inherited sizing. [[1]](diffhunk://#diff-b8b88e6ae3eebc39bc958b583f4fa6dfac40c954d7bd54a67084acbf06bc36fdL89-R90) [[2]](diffhunk://#diff-42fdca7d7444a1490f0f5f191fa753ad70f494e5741176fbe606902f87885aa4L285-R266)
* Standardized the camera position and field of view for the 3D canvas, removing device-specific adjustments and setting a fixed camera distance and FOV.

These changes should make the Skills Sphere component more visually consistent and easier to reason about, while also improving maintainability by reducing device-specific code.