### PR TITLE
feat: update lodash to version 4.18.0 in package.json and package-lock.json for client and server

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6565,9 +6565,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
       "dev": true,
       "license": "MIT"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,7 @@
   },
   "overrides": {
     "esbuild": "0.25.0",
-    "lodash": "4.17.23",
+    "lodash": "4.18.0",
     "serialize-javascript": "7.0.5",
     "flatted": "3.4.2",
     "picomatch": "4.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "Portfolio",
       "devDependencies": {
         "glob": "^11.1.0",
         "sharp": "^0.34.5"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1017,9 +1017,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,7 @@
     "nodemon": "^3.1.11"
   },
   "overrides": {
-    "lodash": "4.17.23",
+    "lodash": "4.18.0",
     "qs": "6.14.2",
     "path-to-regexp": "0.1.13"
   }


### PR DESCRIPTION
This pull request updates the version of the `lodash` dependency from `4.17.23` to `4.18.0` in both the client and server packages. Note that `lodash@4.18.0` is a deprecated release, and the deprecation warning recommends using `lodash@4.17.21` instead.

Dependency updates:

* Updated `lodash` version from `4.17.23` to `4.18.0` in `client/package.json` and `server/package.json`, as well as in their respective lock files (`package-lock.json`). [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL58-R58) [[2]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L44-R44) [[3]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL6568-R6571) [[4]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L1020-R1023)
* The lock files now include a deprecation warning for `lodash@4.18.0`, suggesting to use `lodash@4.17.21` instead. [[1]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL6568-R6571) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L1020-R1023)